### PR TITLE
chore: tidy up CI, add release workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [target.'cfg(target_os="linux")']
-rustflags = ["-C", "link-arg=-fuse-ld=mold"] 
+# using mold breaks cargo cross on musl (the image is based on focal, which does not have a mold package)
+#rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
 [target.'cfg(target_os="windows")']
 rustflags = ["-C", "link-arg=-fuse-ld=lld"] 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,32 +19,40 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ubuntu-22.04]
-    runs-on: ${{ matrix.platform }}
+        include:
+        - build: x86_64-musl
+          host: ubuntu-latest
+          target: x86_64-unknown-linux-musl
+          rust: stable
+    runs-on: ${{ matrix.host }}
     steps:
     - uses: actions/checkout@v4
-    - name: Set minimal profile (Windows only)
-      if: matrix.platform == 'windows-latest'
-      run: rustup set profile minimal
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+    #- name: Set minimal profile (Windows only)
+    #  if: matrix.host == 'windows-latest'
+    #  run: rustup set profile minimal
     - uses: Swatinem/rust-cache@v2
       with:
-        key: "${{matrix.platform}}"
+        key: "${{matrix.build}}"
     - name: install packages (ubuntu)
-      if: matrix.platform == 'ubuntu-22.04'
-      run: sudo apt-get update && sudo apt-get -y --no-install-recommends install mold capnproto
+      if: startsWith(matrix.host, 'ubuntu')
+      run: scripts/install-ubuntu-packages
     - name: Build
       run: cargo build --locked
 
   # We only need to run the checks on a single platform
   checks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ubuntu-22.04
+          key: ubuntu-latest
       - name: install packages
-        run: sudo apt-get update && sudo apt-get -y --no-install-recommends install mold capnproto
+        run: scripts/install-ubuntu-packages
       # Checks begin here!
       - run: cargo fmt --all -- --check
       - run: cargo test --locked
@@ -52,4 +60,4 @@ jobs:
       # We care that the benchmarks build and run, not about their numeric output.
       # To keep the CI a bit leaner, do this in the dev profile.
       - run: cargo build --locked --all-targets
-      - run: cargo doc --document-private-items
+      - run: cargo doc --no-deps --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: release
+
+on:
+  release:
+    types: [published]
+  # useful for testing
+  #push:
+  #  branches:
+  #    - misc/ci-auto-release
+
+permissions:
+  contents: write
+
+jobs:
+  binary:
+    strategy:
+      matrix:
+        include:
+        - build: x86_64-musl
+          host: ubuntu-latest
+          target: x86_64-unknown-linux-musl
+          rust: stable
+    runs-on: ${{ matrix.host }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: "${{matrix.build}}"
+    #- name: install packages (ubuntu)
+    #  if: startsWith(matrix.host, 'ubuntu')
+    #  run: scripts/install-ubuntu-packages
+    - uses: taiki-e/upload-rust-binary-action@v1
+      id: build
+      with:
+        bin: qcp
+        token: ${{ secrets.GITHUB_TOKEN }}
+        target: ${{ matrix.target }}
+        include: README.md,LICENSE,CHANGELOG.md
+        leading-dir: true
+        tar: unix
+        zip: windows
+        # dry_run: true # when testing the workflow
+    # Uploading the artifact is useful when testing the workflow in dry-run mode
+    - uses: actions/upload-artifact@v4
+      with:
+        name: binary-${{ matrix.target }}
+        path: ${{ steps.build.outputs.archive }}.tar.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ homepage = "https://github.com/crazyscot/qcp/"
 keywords = [ "networking", "file-transfer", "quic" ]
 categories = [ "command-line-utilities" ]
 
+[profile.release]
+lto = "thin"
+strip = "symbols"
+
 [dependencies]
 anstyle = "1.0.8"
 anyhow = "1.0.89"
@@ -81,3 +85,6 @@ invalid_rust_codeblocks = "deny"
 missing_crate_level_docs = "deny"
 private_intra_doc_links = "deny"
 unescaped_backticks = "deny"
+
+[package.metadata.cross.target.x86_64-unknown-linux-musl]
+pre-build = [ "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install capnproto" ]

--- a/scripts/install-ubuntu-packages
+++ b/scripts/install-ubuntu-packages
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update
+sudo apt-get -y --no-install-recommends install capnproto musl-tools


### PR DESCRIPTION
- use ubuntu-latest; deduplicate apt installation
- rework CI matrix;
- build for musl, not glibc
- add release workflow to create the binary package
- don't use mold (not supported by rust cross)
- enable LTO & strip on release builds