### PR TITLE
Read hosts from ssh_config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dns-lookup"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +748,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +881,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "overload"
@@ -997,6 +1034,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+ "ssh2-config",
  "static_assertions",
  "struct-field-names-as-array",
  "strum_macros",
@@ -1022,7 +1060,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.6",
  "tokio",
  "tracing",
 ]
@@ -1041,7 +1079,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.6",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1111,6 +1149,17 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "yasna",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1359,6 +1408,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "ssh2-config"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98150bad1e8fe53df07f38b53364f4d34e84a6cc2ee9f933e43629571060af65"
+dependencies = [
+ "bitflags",
+ "dirs",
+ "thiserror 1.0.69",
+ "wildmatch",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,11 +1558,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.6",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1829,6 +1910,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ce1ab1f8c62655ebe1350f589c61e505cf94d385bc6a12899442d9081e71fd"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ quinn = { version = "0.11.6", default-features = false, features = ["runtime-tok
 rcgen = { version = "0.13.1" }
 rustls-pki-types = "1.10.0"
 serde = { version = "1.0.216", features = ["derive"] }
+ssh2-config = "0.2.3"
 static_assertions = "1.1.0"
 struct-field-names-as-array = "0.3.0"
 strum_macros = "0.26.4"

--- a/src/client/control.rs
+++ b/src/client/control.rs
@@ -37,13 +37,14 @@ impl Channel {
     /// Opens the control channel, checks the banner, sends the Client Message, reads the Server Message.
     pub async fn transact(
         credentials: &Credentials,
+        remote_host: &str,
         connection_type: ConnectionType,
         display: &MultiProgress,
         config: &Configuration,
         parameters: &Parameters,
     ) -> Result<(Channel, ServerMessage)> {
         trace!("opening control channel");
-        let mut new1 = Self::launch(display, config, parameters, connection_type)?;
+        let mut new1 = Self::launch(display, config, parameters, remote_host, connection_type)?;
         new1.wait_for_banner().await?;
 
         let mut pipe = new1
@@ -79,9 +80,9 @@ impl Channel {
         display: &MultiProgress,
         config: &Configuration,
         parameters: &Parameters,
+        remote_host: &str,
         connection_type: ConnectionType,
     ) -> Result<Self> {
-        let remote_host = parameters.remote_host()?;
         let mut server = tokio::process::Command::new(&config.ssh);
         let _ = server.kill_on_drop(true);
         let _ = match connection_type {
@@ -90,7 +91,7 @@ impl Channel {
         };
         let _ = server.args(&config.ssh_opt);
         let _ = server.args([
-            &remote_host,
+            remote_host,
             "qcp",
             "--server",
             // Remote receive bandwidth = our transmit bandwidth

--- a/src/client/job.rs
+++ b/src/client/job.rs
@@ -8,7 +8,9 @@ use crate::transport::ThroughputMode;
 /// A file source or destination specified by the user
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FileSpec {
-    /// The remote host for the file.
+    /// The remote host for the file. This may be a hostname or an IP address.
+    /// It may also be a _hostname alias_ that matches a Host section in the user's ssh config file.
+    /// (In that case, the ssh config file must specify a HostName.)
     ///
     /// If not present, this is a local file.
     pub host: Option<String>,
@@ -68,13 +70,15 @@ impl CopyJobSpec {
         }
     }
 
-    pub(crate) fn remote_user_host(&self) -> &str {
+    /// The [user@]hostname portion of whichever of the arguments contained a hostname.
+    fn remote_user_host(&self) -> &str {
         self.source
             .host
             .as_ref()
             .unwrap_or_else(|| self.destination.host.as_ref().unwrap())
     }
 
+    /// The hostname portion of whichever of the arguments contained one.
     pub(crate) fn remote_host(&self) -> &str {
         let user_host = self.remote_user_host();
         // It might be user@host, or it might be just the hostname or IP.

--- a/src/client/main_loop.rs
+++ b/src/client/main_loop.rs
@@ -48,14 +48,17 @@ pub async fn client_main(
     // Prep --------------------------
     let job_spec = crate::client::CopyJobSpec::try_from(&parameters)?;
     let credentials = Credentials::generate()?;
+    let remote_host = job_spec.remote_host();
+
     // If the user didn't specify the address family: we do the DNS lookup, figure it out and tell ssh to use that.
     // (Otherwise if we resolved a v4 and ssh a v6 - as might happen with round-robin DNS - that could be surprising.)
-    let remote_address = lookup_host_by_family(job_spec.remote_host(), config.address_family)?;
+    let remote_address = lookup_host_by_family(remote_host, config.address_family)?;
 
     // Control channel ---------------
     timers.next("control channel");
     let (mut control, server_message) = Channel::transact(
         &credentials,
+        remote_host,
         remote_address.into(),
         &display,
         config,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,6 +13,7 @@ pub use job::FileSpec;
 mod main_loop;
 mod meter;
 mod progress;
+pub mod ssh;
 
 #[allow(clippy::module_name_repetitions)]
 pub use main_loop::client_main;

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -98,9 +98,3 @@ impl TryFrom<&Parameters> for CopyJobSpec {
         })
     }
 }
-
-impl Parameters {
-    pub(crate) fn remote_host(&self) -> anyhow::Result<String> {
-        Ok(CopyJobSpec::try_from(self)?.remote_host().to_string())
-    }
-}

--- a/src/client/ssh.rs
+++ b/src/client/ssh.rs
@@ -1,0 +1,110 @@
+//! Interaction with ssh configuration
+// (c) 2024 Ross Younger
+
+use std::{fs::File, io::BufReader};
+
+use ssh2_config::{ParseRule, SshConfig};
+use tracing::{debug, warn};
+
+use crate::os::{AbstractPlatform as _, Platform};
+
+/// Attempts to resolve a hostname from a single OpenSSH-style config file
+///
+/// If `path` is None, uses the default user ssh config file.
+fn resolve_one(path: Option<&str>, host: &str) -> Option<String> {
+    let source = path.unwrap_or("~/.ssh/config");
+    let result = match path {
+        Some(p) => {
+            let mut reader = match File::open(p) {
+                Ok(f) => BufReader::new(f),
+                Err(e) => {
+                    // This is not automatically an error, as the file might not exist.
+                    debug!("Unable to read {p}; continuing without. {e}");
+                    return None;
+                }
+            };
+            SshConfig::default().parse(&mut reader, ParseRule::ALLOW_UNKNOWN_FIELDS)
+        }
+        None => SshConfig::parse_default_file(ParseRule::ALLOW_UNKNOWN_FIELDS),
+    };
+    let cfg = match result {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            warn!("Unable to parse {source}; continuing without. [{e}]");
+            return None;
+        }
+    };
+
+    cfg.query(host).host_name.inspect(|h| {
+        debug!("Using hostname '{h}' for '{host}' (from {source})");
+    })
+}
+
+/// Attempts to resolve hostname aliasing from the user's and system's ssh config files to resolve aliasing.
+///
+/// ## Returns
+/// Some(hostname) if any config file matched.
+/// None if no config files matched.
+///
+/// ## ssh_config features not currently supported
+/// * Include directives
+/// * Match patterns
+/// * CanonicalizeHostname and friends
+#[must_use]
+pub fn resolve_host_alias(host: &str) -> Option<String> {
+    let files = vec![None, Some(Platform::system_ssh_config())];
+    files.into_iter().find_map(|it| resolve_one(it, host))
+}
+
+#[cfg(test)]
+mod test {
+    use super::resolve_one;
+    use crate::util::make_test_tempfile;
+
+    #[test]
+    fn hosts_resolve() {
+        let (path, _dir) = make_test_tempfile(
+            r"
+        Host aaa
+            HostName zzz
+        Host bbb ccc.ddd
+            HostName yyy
+        ",
+            "test_ssh_config",
+        );
+        let f = path.to_string_lossy().to_string();
+        assert!(resolve_one(Some(&f), "nope").is_none());
+        assert_eq!(resolve_one(Some(&f), "aaa").unwrap(), "zzz");
+        assert_eq!(resolve_one(Some(&f), "bbb").unwrap(), "yyy");
+        assert_eq!(resolve_one(Some(&f), "ccc.ddd").unwrap(), "yyy");
+    }
+
+    #[test]
+    fn wildcards_match() {
+        let (path, _dir) = make_test_tempfile(
+            r"
+        Host *.bar
+            HostName baz
+        Host 10.11.*.13
+            # this is a silly example but it shows that wildcards match by IP
+            HostName wibble
+        Host fr?d
+            hostname barney
+        ",
+            "test_ssh_config",
+        );
+        let f = path.to_string_lossy().to_string();
+        assert_eq!(resolve_one(Some(&f), "foo.bar").unwrap(), "baz");
+        assert_eq!(resolve_one(Some(&f), "qux.qix.bar").unwrap(), "baz");
+        assert!(resolve_one(Some(&f), "qux.qix").is_none());
+        assert_eq!(resolve_one(Some(&f), "10.11.12.13").unwrap(), "wibble");
+        assert_eq!(resolve_one(Some(&f), "10.11.0.13").unwrap(), "wibble");
+        assert_eq!(resolve_one(Some(&f), "10.11.256.13").unwrap(), "wibble"); // yes I know this isn't a real IP address
+        assert!(resolve_one(Some(&f), "10.11.0.130").is_none());
+
+        assert_eq!(resolve_one(Some(&f), "fred").unwrap(), "barney");
+        assert_eq!(resolve_one(Some(&f), "frid").unwrap(), "barney");
+        assert!(resolve_one(Some(&f), "freed").is_none());
+        assert!(resolve_one(Some(&f), "fredd").is_none());
+    }
+}

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -372,14 +372,9 @@ impl Display for DisplayAdapter<'_> {
 
 #[cfg(test)]
 mod test {
-    use std::path::PathBuf;
-
-    use serde::Deserialize;
-    use tempfile::TempDir;
-
-    use crate::util::PortRange;
-
     use crate::config::{Configuration, Configuration_Optional, Manager};
+    use crate::util::{make_test_tempfile, PortRange};
+    use serde::Deserialize;
 
     #[test]
     fn defaults() {
@@ -407,18 +402,10 @@ mod test {
         assert_eq!(expected, result);
     }
 
-    fn make_tempfile(data: &str, filename: &str) -> (PathBuf, TempDir) {
-        let tempdir = tempfile::tempdir().unwrap();
-        let path = tempdir.path().join(filename);
-        std::fs::write(&path, data).expect("Unable to write tempfile");
-        // println!("temp file is {:?}", &path);
-        (path, tempdir)
-    }
-
     #[test]
     fn dump_config_cli_and_toml() {
         // Not a unit test as such; this is a human test
-        let (path, _tempdir) = make_tempfile(
+        let (path, _tempdir) = make_test_tempfile(
             r#"
             tx = 42
             congestion = "Bbr"
@@ -440,7 +427,7 @@ mod test {
     #[test]
     fn unparseable_toml() {
         // This is a semi unit test; there is one assert, but the secondary goal is that it outputs something sensible
-        let (path, _tempdir) = make_tempfile(
+        let (path, _tempdir) = make_test_tempfile(
             r"
             a = 1
             rx 123 # this line is a syntax error
@@ -465,7 +452,7 @@ mod test {
             magic_: i32,
         }
 
-        let (path, _tempdir) = make_tempfile(
+        let (path, _tempdir) = make_test_tempfile(
             r"
             rx = true # invalid
             rtt = 3.14159 # also invalid
@@ -494,7 +481,7 @@ mod test {
             t2: PortRange,
             t3: PortRange,
         }
-        let (path, _tempdir) = make_tempfile(
+        let (path, _tempdir) = make_test_tempfile(
             r#"
             t1 = 1234
             t2 = "2345"
@@ -535,7 +522,7 @@ mod test {
             ii: Vec<i32>,
         }
 
-        let (path, _tempdir) = make_tempfile(
+        let (path, _tempdir) = make_test_tempfile(
             r"
             ii = [1,2,3,4,6]
         ",
@@ -554,7 +541,7 @@ mod test {
             _p: PortRange,
         }
 
-        let (path, _tempdir) = make_tempfile(
+        let (path, _tempdir) = make_test_tempfile(
             r#"
             _p = "234-123"
         "#,

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -28,10 +28,26 @@ pub trait SocketOptions {
     fn force_recvbuf(&mut self, size: usize) -> Result<()>;
 }
 
+/// General platform abstraction trait.
+/// The active implementation should be pulled into this crate
+/// Implementations should be called `Platform`, e.g. [unix::Platform].
+///
+/// Usage:
+/// ```
+///    use qcp::os::Platform;
+///    use qcp::os::AbstractPlatform as _;
+///    println!("{}", Platform::system_ssh_config());
+/// ```
+pub trait AbstractPlatform {
+    /// Path to the system ssh config file.
+    /// On most platforms this will be `/etc/ssh/ssh_config`
+    fn system_ssh_config() -> &'static str;
+}
+
 #[cfg(any(unix, doc))]
 mod unix;
 
 #[cfg(any(unix, doc))]
-pub(crate) use unix::*;
+pub use unix::*;
 
 static_assertions::assert_cfg!(unix, "This OS is not yet supported");

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -87,3 +87,13 @@ can create a file /etc/sysctl.d/20-qcp.conf containing:
     }
     // TODO add other OS-specific notes here
 }
+
+/// Concretions for Unix platforms
+#[derive(Debug, Clone, Copy)]
+pub struct Platform {}
+
+impl super::AbstractPlatform for Platform {
+    fn system_ssh_config() -> &'static str {
+        "/etc/ssh/ssh_config"
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -26,3 +26,14 @@ pub use port_range::PortRange;
 
 mod optionalify;
 pub use optionalify::{derive_deftly_template_Optionalify, insert_if_some};
+
+#[cfg(test)]
+pub(crate) fn make_test_tempfile(
+    data: &str,
+    filename: &str,
+) -> (std::path::PathBuf, tempfile::TempDir) {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path = tempdir.path().join(filename);
+    std::fs::write(&path, data).expect("Unable to write tempfile");
+    (path, tempdir)
+}


### PR DESCRIPTION
This will resolve #22 and should appear in the 0.2 release.

ssh_config features supported:
* One host with multiple aliases (e.g. `Host foo bar`)
* Wildcard matches

ssh_config features not currently supported (largely because the ssh2_config crate does not support them):
* Include directives
* Match patterns
* CanonicalizeHostname and friends
