### PR TITLE
Revamp control channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,9 +430,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "engineering-repr"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee6e941bd84e2720a495364cabab0af1ca7563b9cda4e9240ad405ed7b70d3a"
+checksum = "d60b04132ff0d628a3c7163c85f6225758b7d362b8bb6d8afe45ff9e0ddbc3fc"
 dependencies = [
  "num-integer",
  "num-rational",
@@ -1025,6 +1025,7 @@ dependencies = [
  "serde",
  "serde_bare",
  "serde_json",
+ "serde_repr",
  "serde_test",
  "static_assertions",
  "struct-field-names-as-array",
@@ -1341,6 +1342,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ derive_more = { version = "1.0.0", features = ["constructor"] }
 dirs = "6.0.0"
 dns-lookup = "2.0.4"
 document-features = "0.2.10"
-engineering-repr = { version = "1.0.0", features = ["serde"] }
+engineering-repr = { version = "1.1.0", features = ["serde"] }
 figment = { version = "0.10.19" }
 futures-util = { version = "0.3.31", default-features = false }
 gethostname = "0.5.0"
@@ -52,6 +52,7 @@ rcgen = { version = "0.13.1" }
 rustls-pki-types = "1.10.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_bare = "0.5.0"
+serde_repr = "0.1.19"
 static_assertions = "1.1.0"
 struct-field-names-as-array = "0.3.0"
 strum = { version = "0.26.3", features = ["derive"]}

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ in a configuration file. See [config] for details.
 
 The brief version:
 
-1. We ssh to the remote machine and run `qcp --server` there
+1. We ssh to the remote machine and run `qcp --server` there (with no further args, i.e. you can use `command="qcp --server"` in your authorized_keys file)
 1. Both sides generate a TLS key and exchange self-signed certs over the ssh pipe between them
 1. We use those certs to set up a QUIC session between the two
 1. We transfer files over QUIC

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -42,7 +42,8 @@ pub(crate) struct CliArgs {
             "help_buffers", "show_config", "config_files",
             "quiet", "statistics", "remote_debug", "profile",
             "ssh", "ssh_options", "remote_port",
-            "source", "destination",
+            "source", "destination", "port", "debug",
+            "tx", "rx", "rtt", "congestion", "initial_congestion_window", "timeout",
         ])
     )]
     pub server: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! ## 📖 How it works
 //!
 //! The brief version:
-//! 1. We ssh to the remote machine and run `qcp --server` there
+//! 1. We ssh to the remote machine and run `qcp --server` there (with no further args, i.e. you can use `command="qcp --server"` in your authorized_keys file)
 //! 1. Both sides generate a TLS key and exchange self-signed certs over the ssh pipe between them
 //! 1. We use those certs to set up a QUIC session between the two
 //! 1. We transfer files over QUIC

--- a/src/protocol/common.rs
+++ b/src/protocol/common.rs
@@ -15,14 +15,13 @@
 //!
 //! Some of the structures in these protocols have a trailing `extension: u8`.
 //! This allows us to add new, optional fields later without a protocol break.
-//! * In v0 of each struct, these must be sent as 0.
+//! * In the original version of each struct, these must be sent as 0.
 //! * A later version can quietly change the definition to `Option<something>`.
 //!
 //! This is on top of the general protocol extension trick of using unions (in Rust, enums with contents)
 //! as described in section 4 of [BARE].
-//! * The downside of this arrangement is that older versions of the software do not understand the newer enum,
-//!   so would choke on it. Nevertheless this scheme is workable, provided there was some sort of protocol
-//!   negotiation phase.
+//! This must itself be used with care:  older versions of the software do not understand any newer enum values,
+//! so would choke on them. This is why the control channel includes [`CompatibilityLevel`](crate::protocol::control::CompatibilityLevel).
 //!
 //! [BARE]: https://www.ietf.org/archive/id/draft-devault-bare-11.html
 //! [serde_bare]: https://docs.rs/serde_bare/latest/serde_bare/

--- a/src/protocol/session.rs
+++ b/src/protocol/session.rs
@@ -172,9 +172,14 @@ impl ProtocolMessage for FileTrailer {}
 
 #[cfg(test)]
 mod test {
-    use crate::protocol::session::FileHeader;
+    use serde_bare::Uint;
 
-    use super::{ResponseV1, Status};
+    use crate::protocol::{
+        common::ProtocolMessage,
+        session::{FileHeader, FileTrailer},
+    };
+
+    use super::{Command, FileHeaderV1, Response, ResponseV1, Status};
 
     #[test]
     fn display() {
@@ -195,5 +200,42 @@ mod test {
         let FileHeader::V1(h) = h;
         assert_eq!(h.size.0, 42);
         assert_eq!(h.filename, "myfile");
+    }
+
+    #[test]
+    fn serialize_command() {
+        let cmd = Command::Get(super::GetArgs {
+            filename: "myfile".to_string(),
+        });
+        let wire = cmd.to_vec().unwrap();
+        let deser = Command::from_slice(&wire).unwrap();
+        assert_eq!(cmd, deser);
+    }
+
+    #[test]
+    fn serialize_response() {
+        let resp = Response::V1(ResponseV1 {
+            status: Status::ItIsADirectory,
+            message: Some("nope".to_string()),
+        });
+        let wire = resp.to_vec().unwrap();
+        let deser = Response::from_slice(&wire).unwrap();
+        assert_eq!(resp, deser);
+    }
+
+    #[test]
+    fn serialize_file_header_trailer() {
+        let head = FileHeader::V1(FileHeaderV1 {
+            size: Uint(12345),
+            filename: "myfile".to_string(),
+        });
+        let wire = head.to_vec().unwrap();
+        let deser = FileHeader::from_slice(&wire).unwrap();
+        assert_eq!(head, deser);
+
+        let trail = FileTrailer::V1;
+        let wire = trail.to_vec().unwrap();
+        let deser = FileTrailer::from_slice(&wire).unwrap();
+        assert_eq!(trail, deser);
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -30,23 +30,28 @@ pub enum ThroughputMode {
     Both,
 }
 
-/// Selects the congestion control algorithm to use
+/// Selects the congestion control algorithm to use.
+/// On the wire, this is serialized as a standard BARE enum.
 #[derive(
     Copy,
     Clone,
     Debug,
+    Default,
     PartialEq,
     Eq,
     strum::Display,
     strum::EnumString,
+    strum::FromRepr,
     strum::VariantNames,
     clap::ValueEnum,
     Serialize,
 )]
 #[strum(serialize_all = "lowercase")] // N.B. this applies to EnumString, not Display
+#[repr(u8)]
 pub enum CongestionControllerType {
     /// The congestion algorithm TCP uses. This is good for most cases.
-    Cubic,
+    #[default]
+    Cubic = 0,
     /// (Use with caution!) An experimental algorithm created by Google,
     /// which increases goodput in some situations
     /// (particularly long and fat connections where the intervening
@@ -55,7 +60,7 @@ pub enum CongestionControllerType {
     /// See
     /// `https://blog.apnic.net/2020/01/10/when-to-use-and-not-use-bbr/`
     /// for more discussion.
-    Bbr,
+    Bbr = 1,
 }
 
 impl<'de> Deserialize<'de> for CongestionControllerType {

--- a/src/util/socket.rs
+++ b/src/util/socket.rs
@@ -106,6 +106,7 @@ pub fn bind_range_for_address(
     for port in range.begin..range.end {
         let result = UdpSocket::bind(SocketAddr::new(addr, port));
         if let Ok(sock) = result {
+            debug!("bound endpoint to UDP port {port}");
             return Ok(sock);
         }
     }


### PR DESCRIPTION
* Adds a Greeting phase to the protocol
* Remove server CLI arguments in favour of fields in the `ClientMessage`, i.e. the remote invocation is now always `qcp --server`