### PR TITLE
Negotiate transport parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 *~
 *.swp
 .temp
-
-# Added by cargo
-
 /target
+/target.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.95",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1775,6 +1776,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bytes = "1.9.0"
 clap = { version = "4.5.27", features = ["wrap_help", "derive", "cargo", "help", "string"] }
 console = "0.15.8"
 derive-deftly = "0.14.2"
-derive_more = { version = "1.0.0", features = ["constructor"] }
+derive_more = { version = "1.0.0", features = ["constructor", "display"] }
 dirs = "6.0.0"
 dns-lookup = "2.0.4"
 document-features = "0.2.10"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -40,7 +40,7 @@ pub(crate) struct CliArgs {
         long, help_heading("Modes"), hide = true,
         conflicts_with_all([
             "help_buffers", "show_config", "config_files",
-            "quiet", "statistics", "remote_debug", "profile",
+            "quiet", "statistics", "remote_debug", "profile", "dry_run",
             "ssh", "ssh_options", "remote_port",
             "source", "destination", "port", "debug",
             "tx", "rx", "rtt", "congestion", "initial_congestion_window", "timeout",

--- a/src/cli/cli_main.rs
+++ b/src/cli/cli_main.rs
@@ -7,6 +7,7 @@ use crate::{
     config::{Configuration, Manager},
     os,
     server::server_main,
+    styles::{ERROR, RESET},
 };
 
 use anstream::println;
@@ -68,7 +69,13 @@ pub async fn cli() -> anyhow::Result<bool> {
             println!("{}", config_manager.to_display_adapter::<Configuration>());
         }
         MainMode::Server => {
-            server_main().await?;
+            return Ok(server_main().await.map_or_else(
+                |e| {
+                    eprintln!("{ERROR}ERROR{RESET} Server: {e}");
+                    false
+                },
+                |()| true,
+            ));
         }
         MainMode::Client(progress) => {
             // this mode may return false

--- a/src/cli/cli_main.rs
+++ b/src/cli/cli_main.rs
@@ -71,9 +71,13 @@ pub async fn cli() -> anyhow::Result<bool> {
             server_main().await?;
         }
         MainMode::Client(progress) => {
-            config_manager.apply_system_default();
             // this mode may return false
-            return client_main(&config_manager.validate()?, progress, args.client_params).await;
+            return client_main(
+                &mut config_manager.validate()?,
+                progress,
+                args.client_params,
+            )
+            .await;
         }
     };
     Ok(true)

--- a/src/cli/cli_main.rs
+++ b/src/cli/cli_main.rs
@@ -73,7 +73,7 @@ pub async fn cli() -> anyhow::Result<bool> {
         MainMode::Client(progress) => {
             // this mode may return false
             return client_main(
-                &mut config_manager.validate()?,
+                &mut config_manager.validate_configuration()?,
                 progress,
                 args.client_params,
             )

--- a/src/cli/cli_main.rs
+++ b/src/cli/cli_main.rs
@@ -51,7 +51,7 @@ pub async fn cli() -> anyhow::Result<bool> {
 
     // Now fold the arguments in with the CLI config (which may fail)
     // (to provoke an error here: `qcp host: host2:`)
-    let config_manager = Manager::try_from(&args)?;
+    let mut config_manager = Manager::try_from(&args)?;
 
     match mode {
         MainMode::HelpBuffers => {
@@ -64,15 +64,16 @@ pub async fn cli() -> anyhow::Result<bool> {
             println!("{:?}", Manager::config_files());
         }
         MainMode::ShowConfig => {
+            config_manager.apply_system_default();
             println!("{}", config_manager.to_display_adapter::<Configuration>());
         }
         MainMode::Server => {
             server_main().await?;
         }
         MainMode::Client(progress) => {
-            let config = config_manager.get::<Configuration>()?.validate()?;
+            config_manager.apply_system_default();
             // this mode may return false
-            return client_main(&config, progress, args.client_params).await;
+            return client_main(&config_manager.validate()?, progress, args.client_params).await;
         }
     };
     Ok(true)

--- a/src/client/control.rs
+++ b/src/client/control.rs
@@ -77,7 +77,7 @@ impl Channel {
     /// Opens the control channel, checks the banner, sends the Client Message, reads the Server Message.
     pub async fn transact(
         credentials: &Credentials,
-        remote_host: &str,
+        ssh_hostname: &str,
         connection_type: ConnectionType,
         display: &MultiProgress,
         manager: &mut Manager,
@@ -87,7 +87,7 @@ impl Channel {
 
         // PHASE 1: BANNER CHECK
 
-        let mut new1 = Self::launch(display, manager, parameters, remote_host, connection_type)?;
+        let mut new1 = Self::launch(display, manager, parameters, ssh_hostname, connection_type)?;
         new1.wait_for_banner().await?;
 
         // PHASE 2: EXCHANGE GREETINGS
@@ -151,7 +151,7 @@ impl Channel {
         display: &MultiProgress,
         manager: &Manager,
         parameters: &Parameters,
-        remote_host: &str,
+        ssh_hostname: &str,
         connection_type: ConnectionType,
     ) -> Result<Self> {
         let working_config = manager.get::<Configuration_Optional>().unwrap_or_default();
@@ -169,7 +169,7 @@ impl Channel {
                 .ssh_options
                 .unwrap_or_else(|| defaults.ssh_options.clone()),
         );
-        let _ = server.args([remote_host, "qcp", "--server"]);
+        let _ = server.args([ssh_hostname, "qcp", "--server"]);
         let _ = server
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/src/client/control.rs
+++ b/src/client/control.rs
@@ -124,7 +124,6 @@ impl Channel {
         trace!("waiting for server message");
         let message = ServerMessage::from_reader_async_framed(&mut new1.output()?)
             .await
-            .inspect_err(|e| eprintln!("{e}"))
             .with_context(|| "error reading server message")?;
 
         trace!("Got server message {message:?}");

--- a/src/client/control.rs
+++ b/src/client/control.rs
@@ -99,11 +99,11 @@ impl Channel {
         }
         .to_writer_async_framed(new1.input()?)
         .await
-        .with_context(|| "error writing client greeting")?;
+        .context("error writing client greeting")?;
 
         let remote_greeting = ServerGreeting::from_reader_async_framed(new1.output()?)
             .await
-            .with_context(|| "error reading server greeting")?;
+            .context("error reading server greeting")?;
 
         debug!("got server greeting {remote_greeting:?}");
 
@@ -119,12 +119,12 @@ impl Channel {
         message
             .to_writer_async_framed(new1.input()?)
             .await
-            .with_context(|| "error writing client message")?;
+            .context("error writing client message")?;
 
         trace!("waiting for server message");
         let message = ServerMessage::from_reader_async_framed(&mut new1.output()?)
             .await
-            .with_context(|| "error reading server message")?;
+            .context("error reading server message")?;
 
         trace!("Got server message {message:?}");
         // FUTURE: ServerMessage V2 will require more logic to unpack the message contents.
@@ -220,7 +220,7 @@ impl Channel {
         let n = reader
             .read_exact(&mut buf[0..1])
             .await
-            .with_context(|| "failed to connect control channel")?;
+            .context("failed to connect control channel")?;
         anyhow::ensure!(n == 1, "control channel closed unexpectedly");
 
         // Now we have a character, apply a timeout to read the rest.
@@ -228,11 +228,11 @@ impl Channel {
         let _ = timeout(Duration::from_secs(1), reader.read_exact(&mut buf[1..]))
             .await
             // outer failure means we timed out:
-            .with_context(|| "timed out reading server banner")?
+            .context("timed out reading server banner")?
             // inner failure is some sort of I/O error or unexpected eof
-            .with_context(|| "error reading control channel")?;
+            .context("error reading control channel")?;
 
-        let read_banner = std::str::from_utf8(&buf).with_context(|| "garbage server banner")?;
+        let read_banner = std::str::from_utf8(&buf).context("garbage server banner")?;
         match read_banner {
             BANNER => (),
             OLD_BANNER => {

--- a/src/client/main_loop.rs
+++ b/src/client/main_loop.rs
@@ -121,7 +121,7 @@ pub async fn client_main(
     let port = control.message.port;
     let config = manager
         .get::<Configuration>()
-        .with_context(|| "assembling final client configuration from server message")?;
+        .context("assembling final client configuration from server message")?;
 
     // Dry run mode ends here! -------
     if parameters.dry_run {
@@ -157,7 +157,7 @@ pub async fn client_main(
         endpoint.connect(server_address_port, &control.message.name)?,
     )
     .await
-    .with_context(|| "UDP connection to QUIC endpoint timed out")??;
+    .context("UDP connection to QUIC endpoint timed out")??;
 
     // Show time! ---------------------
     spinner.set_message("Transferring data");

--- a/src/client/main_loop.rs
+++ b/src/client/main_loop.rs
@@ -57,7 +57,7 @@ fn setup_tracing(
 #[allow(clippy::module_name_repetitions)]
 #[allow(clippy::too_many_lines)]
 pub async fn client_main(
-    manager: &Manager,
+    manager: &mut Manager,
     display: MultiProgress,
     parameters: ClientParameters,
 ) -> anyhow::Result<bool> {

--- a/src/client/main_loop.rs
+++ b/src/client/main_loop.rs
@@ -51,6 +51,10 @@ fn setup_tracing(
 }
 
 /// Main client mode event loop
+///
+/// # Return value
+/// `true` if the requested operation succeeded.
+///
 // Caution: As we are using ProgressBar, anything to be printed to console should use progress.println() !
 #[allow(clippy::module_name_repetitions)]
 #[allow(clippy::too_many_lines)]
@@ -118,6 +122,16 @@ pub async fn client_main(
     let config = manager
         .get::<Configuration>()
         .with_context(|| "assembling final client configuration from server message")?;
+
+    // Dry run mode ends here! -------
+    if parameters.dry_run {
+        info!("Dry run mode selected, not connecting to data channel");
+        info!(
+            "Negotiated network configuration: {}",
+            config.format_transport_config()
+        );
+        return Ok(true);
+    }
 
     // Data channel ------------------
     let server_address_port = match remote_address {

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -57,6 +57,11 @@ pub struct Parameters {
     #[arg(long, action, help_heading("Output"), display_order(0))]
     pub profile: bool,
 
+    /// Connects to a remote server but does not actually transfer any files.
+    /// This is useful to test that the control channel works and when debugging the negotiated bandwidth parameters.
+    #[arg(long, action, help_heading("Configuration"), display_order(0))]
+    pub dry_run: bool,
+
     // JOB SPECIFICAION ====================================================================
     // (POSITIONAL ARGUMENTS!)
     /// The source file. This may be a local filename, or remote specified as HOST:FILE or USER@HOST:FILE.

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -2,9 +2,12 @@
 // (c) 2024 Ross Younger
 
 use crate::os::{AbstractPlatform as _, Platform};
+use crate::styles::{INFO, RESET};
 
-use super::{ssh::SshConfigError, Configuration};
+use super::{ssh::SshConfigError, structure::MINIMUM_BANDWIDTH, Configuration};
 
+use anyhow::Result;
+use engineering_repr::{EngineeringQuantity as EQ, EngineeringRepr};
 use figment::{providers::Serialized, value::Value, Figment, Metadata, Provider};
 use heck::ToUpperCamelCase;
 use serde::Deserialize;
@@ -25,7 +28,6 @@ use tracing::{debug, warn};
 
 /// A [`figment::Provider`](https://docs.rs/figment/latest/figment/trait.Provider.html) that holds
 /// the set of system default options
-#[derive(Default)]
 struct SystemDefault {}
 
 impl SystemDefault {
@@ -43,7 +45,7 @@ impl Provider for SystemDefault {
         figment::value::Map<figment::Profile, figment::value::Dict>,
         figment::Error,
     > {
-        Serialized::defaults(Configuration::default()).data()
+        Serialized::defaults(Configuration::system_default()).data()
     }
 }
 
@@ -72,15 +74,25 @@ impl Default for Manager {
 }
 
 impl Manager {
+    /// Constructor. The structure is set up to extract data for the given `host`, if any.
+    fn new(host: Option<&str>) -> Self {
+        let profile = if let Some(host) = host {
+            figment::Profile::new(host)
+        } else {
+            figment::Profile::Default
+        };
+
+        Self {
+            data: Figment::new().select(profile),
+            host: host.map(std::borrow::ToOwned::to_owned),
+        }
+    }
+
     /// Initialises this structure, reading the set of config files appropriate to the platform
     /// and the current user.
     #[must_use]
     pub fn standard(for_host: Option<&str>) -> Self {
-        let mut new1 = Self {
-            data: Figment::new(),
-            host: for_host.map(std::borrow::ToOwned::to_owned),
-        };
-        new1.merge_provider(SystemDefault::default());
+        let mut new1 = Self::new(for_host);
         // N.B. This may leave data in a fused-error state, if a config file isn't parseable.
         new1.add_config(false, "system", Platform::system_config_path(), for_host);
         new1.add_config(true, "user", Platform::user_config_path(), for_host);
@@ -128,9 +140,9 @@ impl Manager {
     #[must_use]
     #[cfg(test)]
     pub(crate) fn without_files(host: Option<&str>) -> Self {
-        let data = Figment::new().merge(SystemDefault::default());
-        let host = host.map(std::string::ToString::to_string);
-        Self { data, host }
+        let mut result = Self::new(host);
+        result.merge_provider(SystemDefault {});
+        result
     }
 
     /// Merges in a data set, which is some sort of [figment::Provider](https://docs.rs/figment/latest/figment/trait.Provider.html).
@@ -161,6 +173,12 @@ impl Manager {
         }
     }
 
+    /// Applies the system default settings, at a lower priority than everything else
+    pub fn apply_system_default(&mut self) {
+        let f = std::mem::take(&mut self.data);
+        self.data = f.join(SystemDefault {});
+    }
+
     /// Attempts to extract a particular struct from the data.
     ///
     /// Within qcp, `T` is usually [Configuration], but it isn't intrinsically required to be.
@@ -169,17 +187,74 @@ impl Manager {
     where
         T: Deserialize<'de>,
     {
-        let profile = if let Some(host) = &self.host {
-            figment::Profile::new(host)
-        } else {
-            figment::Profile::Default
-        };
+        self.data.extract_lossy::<T>().map_err(SshConfigError::from)
+    }
 
-        self.data
-            .clone()
-            .select(profile)
-            .extract_lossy::<T>()
-            .map_err(SshConfigError::from)
+    /// Attempts to retrieve a named field from the data.
+    /// It is an error if that field is not present.
+    ///
+    /// <div class="warning">You must specify the correct type `T`, or will most likely get an error</div>
+    pub(crate) fn get_field<'de, T>(&self, field: &str) -> anyhow::Result<T>
+    where
+        T: Deserialize<'de>,
+    {
+        let value = self.data.find_value(&field.to_lowercase())?;
+        let res: T = value.deserialize()?;
+        Ok(res)
+    }
+
+    /// Retrieves a named field from the data, or None if it is not there or errored.
+    ///
+    /// <div class="warning">You must specify the correct type `T`, or will most likely get `None`</div>
+    pub(crate) fn get_field_optional<'de, T>(&self, field: &str) -> Option<T>
+    where
+        T: Deserialize<'de>,
+    {
+        let Ok(value) = self.data.find_value(&field.to_lowercase()) else {
+            return None;
+        };
+        value.deserialize().map_or(None, |r| Some(r))
+    }
+
+    /// Performs additional validation checks on the fields present in the configuration, as far as possible.
+    /// This is only useful when the [`Manager`] holds a [`Configuration`].
+    pub fn validate(self) -> Result<Self> {
+        let rtt = self.get_field_optional::<u16>("rtt").unwrap_or(0);
+        if let Some(rx) = self.get_field_optional::<EQ<u64>>("rx") {
+            let rx = u64::from(rx);
+            if rx < MINIMUM_BANDWIDTH {
+                anyhow::bail!(
+                    "The receive bandwidth ({INFO}rx {}{RESET}B) is too small; it must be at least {}",
+                    rx.to_eng(0),
+                    MINIMUM_BANDWIDTH.to_eng(3)
+                );
+            }
+            if rx.checked_mul(rtt.into()).is_none() {
+                anyhow::bail!(
+                    "The receive bandwidth delay product calculation ({INFO}rx {}{RESET}B x {INFO}rtt {}{RESET}ms) overflowed",
+                    rx.to_eng(0),
+                    rtt
+                );
+            }
+        }
+        if let Some(tx) = self.get_field_optional::<EQ<u64>>("tx") {
+            let tx = u64::from(tx);
+            if tx != 0 && tx < MINIMUM_BANDWIDTH {
+                anyhow::bail!(
+                    "The transmit bandwidth ({INFO}rx {}{RESET}B) is too small; it must be at least {}",
+                    tx.to_eng(0),
+                    MINIMUM_BANDWIDTH.to_eng(3)
+                );
+            }
+            if tx.checked_mul(rtt.into()).is_none() {
+                anyhow::bail!(
+                    "The transmit bandwidth delay product calculation ({INFO}rx {}{RESET}B x {INFO}rtt {}{RESET}ms) overflowed",
+                    tx.to_eng(0),
+                    rtt
+                );
+            }
+        }
+        Ok(self)
     }
 }
 
@@ -277,13 +352,11 @@ impl Display for DisplayAdapter<'_> {
     ///
     /// N.B. This function uses CLI styling.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut data = self.source.data.clone();
+        let data = &self.source.data;
 
         let mut output = Vec::<PrettyConfig>::new();
         // First line of the table is special
         let (host_string, host_colour) = if let Some(host) = &self.source.host {
-            let profile = figment::Profile::new(host);
-            data = data.select(profile);
             (host.clone(), Color::FG_GREEN)
         } else {
             ("* (globals)".into(), Color::FG_CYAN)
@@ -325,8 +398,8 @@ mod test {
     fn defaults() {
         let mgr = Manager::without_files(None);
         let result = mgr.get().unwrap();
-        let expected = Configuration::default();
-        assert_eq!(expected, result);
+        let expected = Configuration::system_default();
+        assert_eq!(*expected, result);
     }
 
     #[test]
@@ -338,7 +411,7 @@ mod test {
         };
         let expected = Configuration {
             rx: 12345u64.into(),
-            ..Default::default()
+            ..Configuration::system_default().clone()
         };
 
         let mut mgr = Manager::without_files(None);
@@ -574,5 +647,25 @@ mod test {
         //println!("{mgr:?}");
         let result = mgr.get::<Configuration>().unwrap();
         assert_eq!(10_500_000, result.rx());
+    }
+
+    #[test]
+    fn extract_field() {
+        type EQ = engineering_repr::EngineeringQuantity<u64>;
+        let mgr = Manager::without_files(None);
+        let expected = Configuration::system_default().rx;
+        assert_eq!(mgr.get_field::<EQ>("rx").unwrap(), expected);
+        let _ = mgr
+            .get_field::<bool>("nonexistent")
+            .expect_err("nonexistent field should have failed");
+    }
+
+    #[test]
+    fn extract_field_optional() {
+        type EQ = engineering_repr::EngineeringQuantity<u64>;
+        let mgr = Manager::without_files(None);
+        let expected = Configuration::system_default().rx;
+        assert_eq!(mgr.get_field_optional::<EQ>("rx"), Some(expected));
+        assert_eq!(mgr.get_field_optional::<bool>("nonexistent"), None);
     }
 }

--- a/src/config/ssh/files.rs
+++ b/src/config/ssh/files.rs
@@ -56,11 +56,11 @@ impl HostConfiguration {
     }
 
     pub(crate) fn as_figment(&self) -> Figment {
-        let mut figment = Figment::new();
         let profile = self
             .host
             .as_deref()
             .map_or(figment::Profile::Default, figment::Profile::new);
+        let mut figment = Figment::new().select(profile.clone());
         for (k, v) in &self.data {
             figment = figment.merge(ValueProvider::new(k, v, &profile));
         }

--- a/src/config/structure.rs
+++ b/src/config/structure.rs
@@ -24,7 +24,11 @@ pub(crate) const MINIMUM_BANDWIDTH: u64 = 150;
 
 /// The set of configurable options supported by qcp.
 ///
-/// **Note:** The implementation of `default()` for this struct returns qcp's hard-wired configuration defaults.
+/// Options from the server and client are combined at runtime.
+/// See [`combine_bandwidth_configurations`](crate::transport::combine_bandwidth_configurations) for details.
+///
+/// ### Developer notes
+/// The implementation of `default()` for this struct returns qcp's hard-wired configuration defaults.
 ///
 /// This structure uses the [Optionalify](derive_deftly_template_Optionalify) deftly macro to automatically
 /// define the `Configuration_Optional` struct, which is the same but has all members of type `Option<whatever>`.
@@ -48,6 +52,8 @@ pub struct Configuration {
     /// like `10M` or `256k`. **Note that this is described in BYTES, not bits**;
     /// if (for example) you expect to fill a 1Gbit ethernet connection,
     /// 125M might be a suitable setting.
+    ///
+    /// This parameter is always interpreted as the **local** bandwidth, whether operating in client or server mode.
     #[arg(
         short('b'),
         long,
@@ -59,8 +65,9 @@ pub struct Configuration {
     pub rx: EngineeringQuantity<u64>,
     /// The maximum network bandwidth we expect sending data TO the remote system,
     /// if it is different from the bandwidth FROM the system.
-    ///
     /// (For example, when you are connected via an asymmetric last-mile DSL or fibre profile.)
+    ///
+    /// This parameter is always interpreted as the **local** bandwidth, whether operating in client or server mode.
     ///
     /// If not specified or 0, uses the value of `rx`.
     #[arg(

--- a/src/config/structure.rs
+++ b/src/config/structure.rs
@@ -112,11 +112,12 @@ pub struct Configuration {
         long,
         help_heading("Advanced network tuning"),
         value_name = "bytes",
+        alias("cwnd"),
         display_order(0)
     )]
     pub initial_congestion_window: u64,
 
-    /// Uses the given UDP port or range on the local endpoint.
+    /// Uses the given UDP port or range on the **local** endpoint.
     /// This can be useful when there is a firewall between the endpoints.
     ///
     /// For example: `12345`, `20000-20100`
@@ -174,7 +175,7 @@ pub struct Configuration {
     )]
     pub ssh_options: Vec<String>,
 
-    /// Uses the given UDP port or range on the remote endpoint.
+    /// Uses the given UDP port or range on the **remote** endpoint.
     /// This can be useful when there is a firewall between the endpoints.
     ///
     /// For example: `12345`, `20000-20100`

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,9 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 fn main() -> ExitCode {
     if qcp::cli().unwrap_or_else(|e| {
         if qcp::util::tracing_is_initialised() {
-            tracing::error!("{e}");
+            tracing::error!("{e:#}");
         } else {
-            eprintln!("{ERROR}Error:{RESET} {e}");
+            eprintln!("{ERROR}Error:{RESET} {e:#}");
         }
         false
     }) {

--- a/src/protocol/control.rs
+++ b/src/protocol/control.rs
@@ -335,7 +335,10 @@ impl ClientMessageV1 {
             connection_type,
             port: working.remote_port.map(std::convert::Into::into),
 
-            bandwidth_to_server: working.tx.map(u64::from).map(Uint),
+            bandwidth_to_server: match working.tx.map(u64::from) {
+                None | Some(0) => None,
+                Some(v) => Some(Uint(v)),
+            },
             bandwidth_to_client: working.rx.map(u64::from).map(Uint),
             rtt: working.rtt,
             congestion: working.congestion.map(CongestionController_OnWire),

--- a/src/protocol/control.rs
+++ b/src/protocol/control.rs
@@ -304,13 +304,13 @@ pub struct ClientMessageV1 {
     /// The requested bandwidth to use from server to client (if None, use the same as bandwidth to server)
     pub bandwidth_to_client: Option<Uint>,
     /// The network Round Trip Time, in milliseconds, to use in calculating the bandwidth delay product
-    pub round_trip_time: Option<u16>,
+    pub rtt: Option<u16>,
     /// The congestion control algorithm to use
-    pub congestion_algorithm: Option<CongestionController_OnWire>,
+    pub congestion: Option<CongestionController_OnWire>,
     /// The initial congestion window, if specified
     pub initial_congestion_window: Option<Uint>,
     /// Connection timeout for the QUIC endpoints, in seconds
-    pub quic_timeout: Option<u16>,
+    pub timeout: Option<u16>,
 
     /// Extension field, reserved for future expansion; for now, must be set to 0
     pub extension: u8,
@@ -339,10 +339,10 @@ impl ClientMessageV1 {
 
             bandwidth_to_server: working.tx.map(u64::from).map(Uint),
             bandwidth_to_client: working.rx.map(u64::from).map(Uint),
-            round_trip_time: working.rtt,
-            congestion_algorithm: working.congestion.map(CongestionController_OnWire),
+            rtt: working.rtt,
+            congestion: working.congestion.map(CongestionController_OnWire),
             initial_congestion_window: working.initial_congestion_window.map(Uint),
-            quic_timeout: working.timeout,
+            timeout: working.timeout,
 
             extension: 0,
         }
@@ -363,9 +363,9 @@ impl Provider for ClientMessageV1 {
         // N.B. storing tx & rx as integers here requires engineering_repr 1.1.0.
         insert_if_some(&mut dict, "rx", self.bandwidth_to_server.map(|v| v.0))?;
         insert_if_some(&mut dict, "tx", self.bandwidth_to_client.map(|v| v.0))?;
-        insert_if_some(&mut dict, "rtt", self.round_trip_time)?;
-        insert_if_some(&mut dict, "congestion", self.congestion_algorithm)?;
-        insert_if_some(&mut dict, "timeout", self.quic_timeout)?;
+        insert_if_some(&mut dict, "rtt", self.rtt)?;
+        insert_if_some(&mut dict, "congestion", self.congestion)?;
+        insert_if_some(&mut dict, "timeout", self.timeout)?;
         insert_if_some(
             &mut dict,
             "initial_congestion_window",
@@ -388,10 +388,10 @@ impl Display for ClientMessageV1 {
             self.port,
             self.bandwidth_to_client,
             self.bandwidth_to_server,
-            self.round_trip_time,
-            self.congestion_algorithm,
+            self.rtt,
+            self.congestion,
             self.initial_congestion_window,
-            self.quic_timeout
+            self.timeout
         )
     }
 }
@@ -429,13 +429,13 @@ pub struct ServerMessageV1 {
     /// The final bandwidth to use from server to client
     pub bandwidth_to_client: Uint,
     /// The final round-trip-time to use on the connection
-    pub round_trip_time: u16,
+    pub rtt: u16,
     /// The congestion control algorithm to use
-    pub congestion_algorithm: CongestionController_OnWire,
+    pub congestion: CongestionController_OnWire,
     /// The initial congestion window to use (0 means "use algorithm default")
     pub initial_congestion_window: Uint,
     /// Connection timeout for the QUIC endpoints, in seconds
-    pub quic_timeout: u16,
+    pub timeout: u16,
 
     /// If non-zero length, this is a warning message to be relayed to a human
     pub warning: String,
@@ -461,9 +461,9 @@ impl Provider for ServerMessageV1 {
         insert("tx", self.bandwidth_to_server.0.into());
         insert("rx", self.bandwidth_to_client.0.into());
 
-        insert("rtt", self.round_trip_time.into());
-        insert("congestion", self.congestion_algorithm.0.to_string().into());
-        insert("timeout", self.quic_timeout.into());
+        insert("rtt", self.rtt.into());
+        insert("congestion", self.congestion.0.to_string().into());
+        insert("timeout", self.timeout.into());
         insert(
             "initial_congestion_window",
             self.initial_congestion_window.0.into(),
@@ -710,7 +710,7 @@ mod test {
             assert_eq!(detail.bandwidth_to_server.unwrap().0, 42);
             assert_eq!(detail.bandwidth_to_client.unwrap().0, 89);
             assert_eq!(
-                detail.congestion_algorithm,
+                detail.congestion,
                 Some(CongestionController_OnWire(CongestionControllerType::Bbr))
             );
         } else {
@@ -727,10 +727,10 @@ mod test {
             name: "hello".to_string(),
             bandwidth_to_client: Uint(123),
             bandwidth_to_server: Uint(456),
-            round_trip_time: 789,
-            congestion_algorithm: CongestionController_OnWire(CongestionControllerType::Bbr),
+            rtt: 789,
+            congestion: CongestionController_OnWire(CongestionControllerType::Bbr),
             initial_congestion_window: Uint(4321),
-            quic_timeout: 42,
+            timeout: 42,
             warning: String::from("this is a warning"),
             extension: 0,
         });

--- a/src/server.rs
+++ b/src/server.rs
@@ -56,12 +56,12 @@ pub async fn server_main() -> anyhow::Result<()> {
     }
     .to_writer_async_framed(&mut stdout)
     .await
-    .with_context(|| "sending server greeting")?;
+    .context("sending server greeting")?;
     stdout.flush().await?;
 
     let remote_greeting = ClientGreeting::from_reader_async_framed(&mut stdin)
         .await
-        .with_context(|| "failed to read client greeting")?;
+        .context("failed to read client greeting")?;
 
     let manager = Manager::standard(None); // Server does not use Host-specific configuration at the moment.
     setup_tracing(
@@ -145,7 +145,7 @@ pub async fn server_main() -> anyhow::Result<()> {
     let (stats_tx, mut stats_rx) = oneshot::channel();
     if let Some(conn) = timeout(config.timeout_duration(), endpoint.accept())
         .await
-        .with_context(|| "Timed out waiting for QUIC connection")?
+        .context("Timed out waiting for QUIC connection")?
     {
         let _ = tasks.spawn(async move {
             let result = handle_connection(conn, file_buffer_size).await;

--- a/src/server.rs
+++ b/src/server.rs
@@ -72,7 +72,7 @@ pub async fn server_main() -> anyhow::Result<()> {
             .time_format
             .unwrap_or_default(),
     )?;
-    let _span = tracing::error_span!("REMOTE").entered();
+    let _span = tracing::error_span!("Server").entered();
 
     debug!("got client greeting {remote_greeting:?}");
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -120,10 +120,10 @@ pub async fn server_main() -> anyhow::Result<()> {
         name: credentials.hostname,
         bandwidth_to_server: Uint(config.rx()),
         bandwidth_to_client: Uint(config.tx()),
-        round_trip_time: config.rtt,
-        congestion_algorithm: config.congestion.into(),
+        rtt: config.rtt,
+        congestion: config.congestion.into(),
         initial_congestion_window: Uint(config.initial_congestion_window),
-        quic_timeout: config.timeout,
+        timeout: config.timeout,
         warning,
         extension: 0,
     })

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -247,9 +247,12 @@ pub fn combine_bandwidth_configurations(
             defaults.initial_congestion_window,
             |a, _| Ok::<u64, Infallible>(a),
         )?,
-        port: negotiate_mixed(server.port, client.port, defaults.port, |a, b| {
-            a.combine(b.into())
-        })?,
+        port: negotiate_mixed(
+            server.port,
+            client.port,
+            defaults.port,
+            crate::util::PortRange::combine,
+        )?,
         timeout: negotiate(
             server.timeout,
             client.timeout,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -190,10 +190,10 @@ where
 /// | ---                    | ---                 | ---       |
 /// | Client [`rx`](Configuration#structfield.rx) / Server [`tx`](Configuration#structfield.tx) | [`bandwidth_to_client`](ClientMessageV1#structfield.bandwidth_to_client) | Use the smaller of the two |
 /// | Client [`tx`](Configuration#structfield.tx) / Server [`rx`](Configuration#structfield.rx) | [`bandwidth_to_server`](ClientMessageV1#structfield.bandwidth_to_server) | Use the smaller of the two |
-/// | [`rtt`](Configuration#structfield.rtt) |  [`round_trip_time`](ClientMessageV1#structfield.round_trip_time) | Client preference wins |
-/// | [`congestion`](Configuration#structfield.congestion) | [`congestion_algorithm`](ClientMessageV1#structfield.congestion_algorithm) | If the two prefs match, use that; if not, error |
+/// | [`rtt`](Configuration#structfield.rtt) |  [`rtt`](ClientMessageV1#structfield.rtt) | Client preference wins |
+/// | [`congestion`](Configuration#structfield.congestion) | [`congestion`](ClientMessageV1#structfield.congestion) | If the two prefs match, use that; if not, error |
 /// | [`initial_congestion_window`](Configuration#structfield.initial_congestion_window) | [`initial_congestion_window`](ClientMessageV1#structfield.initial_congestion_window) | Client preference wins |
-/// | [`timeout`](Configuration#structfield.timeout) | [`quic_timeout`](ClientMessageV1#structfield.quic_timeout) | Client preference wins |
+/// | [`timeout`](Configuration#structfield.timeout) | [`timeout`](ClientMessageV1#structfield.timeout) | Client preference wins |
 /// | Client [`remote_port`](Configuration#structfield.remote_port) / Server [`port`](ClientMessageV1#structfield.port) | [`port`](ClientMessageV1#structfield.port) | Treat port `0` as "no preference". Compute the intersection of the two ranges. If they do not intersect, error. |
 ///
 /// # Return value
@@ -230,15 +230,10 @@ pub fn combine_bandwidth_configurations(
             |a, b| Ok::<u64, Infallible>(std::cmp::min(a, b)),
         )?
         .into(),
-        rtt: negotiate(
-            server.rtt,
-            client.round_trip_time,
-            defaults.rtt,
-            client_wins,
-        )?,
+        rtt: negotiate(server.rtt, client.rtt, defaults.rtt, client_wins)?,
         congestion: negotiate_mixed(
             server.congestion,
-            client.congestion_algorithm,
+            client.congestion,
             defaults.congestion,
             |_, _| {
                 anyhow::bail!(
@@ -257,7 +252,7 @@ pub fn combine_bandwidth_configurations(
         })?,
         timeout: negotiate(
             server.timeout,
-            client.quic_timeout,
+            client.timeout,
             defaults.timeout,
             client_wins,
         )?,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,6 +16,7 @@ pub mod stats;
 pub mod time;
 
 mod tracing;
+pub(crate) use tracing::trace_level;
 pub use tracing::{is_initialized as tracing_is_initialised, setup as setup_tracing, TimeFormat};
 
 mod port_range;

--- a/src/util/optionalify.rs
+++ b/src/util/optionalify.rs
@@ -114,6 +114,15 @@ define_derive_deftly! {
             Ok(profile_map)
         }
     }
+    impl From<&$tdeftype> for $OPTIONAL_TYPE {
+        fn from(value: &$tdeftype) -> Self {
+            Self {
+                $(
+                    $fname: Some(value.$fname.clone()),
+                )
+            }
+        }
+    }
 }
 
 #[allow(clippy::module_name_repetitions)]

--- a/src/util/port_range.rs
+++ b/src/util/port_range.rs
@@ -6,8 +6,6 @@ use serde::{
 };
 use std::{fmt::Display, str::FromStr};
 
-use crate::protocol::control::PortRange_OnWire;
-
 /// A range of UDP port numbers.
 ///
 /// Port 0 is allowed with the usual meaning ("any available port"), but 0 may not form part of a range.
@@ -90,28 +88,22 @@ impl PortRange {
 
     /// Look at the configured and client-requested port ranges, determine if a solution can be found
     /// and return it if so.
-    pub(crate) fn combine(self, theirs: Option<PortRange_OnWire>) -> anyhow::Result<PortRange> {
+    pub(crate) fn combine(self, theirs: PortRange) -> anyhow::Result<PortRange> {
         Ok(if self.is_default() {
-            // no config this side; client's prefs win
-            match theirs {
-                Some(pr) => pr.into(),
-                None => PortRange::default(),
-            }
+            // no config this side; other prefs win
+            theirs
+        } else if theirs.is_default() {
+            // we win by default
+            self
         } else {
-            match theirs {
-                None => self, // no client pref; we win
-                Some(theirs) => {
-                    // This is the tricky case.. both sides have expressed a preference.
-                    // Intersect both preferences. If that results in no solution, report error.
-                    let begin = std::cmp::max(self.begin, theirs.begin);
-                    let end = std::cmp::min(self.end, theirs.end);
-                    anyhow::ensure!(
-                        begin <= end,
-                        "requested port range {theirs} could not be satisfied (our config: {self})"
-                    );
-                    PortRange { begin, end }
-                }
-            }
+            // Intersect both preferences. If that results in no solution, report error.
+            let begin = std::cmp::max(self.begin, theirs.begin);
+            let end = std::cmp::min(self.end, theirs.end);
+            anyhow::ensure!(
+                begin <= end,
+                "requested port range {theirs} could not be satisfied (our config: {self})"
+            );
+            PortRange { begin, end }
         })
     }
 }
@@ -129,7 +121,6 @@ impl<'de> serde::Deserialize<'de> for PortRange {
 #[cfg(test)]
 mod tests {
     use super::PortRange as ConfigPortRange;
-    use crate::protocol::control::PortRange_OnWire as ProtoPortRange;
     use std::str::FromStr;
 
     type Uut = super::PortRange;
@@ -176,40 +167,25 @@ mod tests {
     }
 
     #[test]
-    fn port_range_easy_cases() {
-        let config = ConfigPortRange { begin: 42, end: 88 };
-        let request = ProtoPortRange { begin: 77, end: 99 };
-        assert_eq!(
-            ConfigPortRange::default().combine(None).unwrap(),
-            ConfigPortRange::default()
-        );
-        assert_eq!(config.combine(None).unwrap(), config);
-        assert_eq!(
-            ConfigPortRange::default().combine(Some(request)).unwrap(),
-            request.into()
-        );
-    }
-
-    #[test]
-    fn port_range_tricky_cases() {
-        fn cpr(begin: u16, end: u16) -> ConfigPortRange {
+    fn port_range_combine() {
+        fn pr(begin: u16, end: u16) -> Uut {
             ConfigPortRange { begin, end }
         }
-        #[allow(clippy::unnecessary_wraps)]
-        fn ppr(begin: u16, end: u16) -> Option<ProtoPortRange> {
-            Some(ProtoPortRange { begin, end })
-        }
 
-        let config = cpr(42, 88);
+        let config = pr(42, 88);
+        // easy case: defaults
+        assert_eq!(Uut::default().combine(config).unwrap(), config);
+        assert_eq!(config.combine(Uut::default()).unwrap(), config);
+
         // overlap one end
-        assert_eq!(config.combine(ppr(77, 99)).unwrap(), cpr(77, 88));
+        assert_eq!(config.combine(pr(77, 99)).unwrap(), pr(77, 88));
         // overlap the other end
-        assert_eq!(config.combine(ppr(5, 49)).unwrap(), cpr(42, 49));
+        assert_eq!(config.combine(pr(5, 49)).unwrap(), pr(42, 49));
         // superset
-        assert_eq!(config.combine(ppr(5, 123)).unwrap(), cpr(42, 88));
+        assert_eq!(config.combine(pr(5, 123)).unwrap(), pr(42, 88));
         // subset
-        assert_eq!(config.combine(ppr(51, 62)).unwrap(), cpr(51, 62));
+        assert_eq!(config.combine(pr(51, 62)).unwrap(), pr(51, 62));
         // disjoint
-        let _ = config.combine(ppr(123, 456)).expect_err("failure expected");
+        let _ = config.combine(pr(123, 456)).expect_err("failure expected");
     }
 }

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -32,6 +32,17 @@ const STANDARD_ENV_VAR: &str = "RUST_LOG";
 /// Environment variable that controls what gets logged to file
 const LOG_FILE_DETAIL_ENV_VAR: &str = "RUST_LOG_FILE_DETAIL";
 
+/// Computes the trace level for a given set of [ClientParameters]
+pub(crate) fn trace_level(args: &crate::client::Parameters) -> &str {
+    if args.debug {
+        "debug"
+    } else if args.quiet {
+        "error"
+    } else {
+        "info"
+    }
+}
+
 /// Selects the format of time stamps in output messages
 #[derive(
     Copy,


### PR DESCRIPTION
This PR includes a breaking protocol change to negotiate transport configuration.
The server and client configurations are now treated as preference, with item-specific rules for determining how to resolve clashes.