### PR TITLE
chore: add revision tag to Nix build

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,6 +9,9 @@ rustPlatform.buildRustPackage rec {
   pname = "qcp";
   version = "0.3.3";
 
+  GITHUB_REF_TYPE = "tag";
+  GITHUB_REF_NAME = version;
+
   src = fetchFromGitHub {
     owner = "crazyscot";
     repo = pname;


### PR DESCRIPTION
Removes the `+gnunkown` tag since these are built directly from the Git flags. This fixes the fact that git tags can't be pulled since it's working off of archives and not git checkouts.

As discussed in https://github.com/crazyscot/qcp/pull/76