### PR TITLE
chore: update nix to v0.4.1

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,44 +1,64 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
   rustPlatform,
+  versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qcp";
-  version = "0.3.3";
+  version = "0.4.1";
 
+  # Tags required to fix the binary version
   GITHUB_REF_TYPE = "tag";
-  GITHUB_REF_NAME = version;
+  GITHUB_REF_NAME = finalAttrs.version;
 
   src = fetchFromGitHub {
     owner = "crazyscot";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-NlRM8FGYBmvT7KDOYTyUWTeERa96UPebuyicncJ4ANY=";
+    repo = "qcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BCUhj60Y4QyE7EFcbfKgkEz8qULD1ONFtdqVo2DJot0=";
   };
 
-  cargoHash = "sha256-KfsNfvCPpm/6oaUa+H4raIxou+udIuYEWhng2ddi68Y=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-IFIAvFvkvMW/BBC16fP67Hhg616QqcTsF1v+V8Lt1iI=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage $src/qcp/misc/qcp.1 $src/qcp/misc/qcp_config.5
+    install -Dm644 $src/qcp/misc/20-qcp.conf $out/etc/sysctl.d/20-qcp.conf
+    install -Dm644 $src/qcp/misc/qcp.conf $out/etc/qcp.conf
+  '';
 
   checkFlags = [
     # SSH home directory tests will not work in nix sandbox
     "--skip=config::ssh::includes::test::home_dir"
+    "--skip=control::process::test::ssh_no_such_host"
+    # Attempts to reach outside of the nix sandbox
+    "--skip=os::unix::test::config_paths"
+    # Permission checks in the sandbox appear to always fail
+    "--skip=session::get::test::permission_denied"
+    # Multiple network tests will fail in sanbox
+    "--skip=util::dns::tests::ipv4"
+    "--skip=util::dns::tests::ipv6"
+    # Tracing attempts to access stdout and angers the sandbox
+    "--skip=util::tracing::test::test_create_layers_with_invalid_level"
   ];
+  checkType = "debug";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "The QUIC Copier (qcp) is an experimental high-performance remote file copy utility for long-distance internet connections.";
+    description = "Experimental high-performance remote file copy utility for long-distance internet connections";
     homepage = "https://github.com/crazyscot/qcp";
+    changelog = "https://github.com/crazyscot/qcp/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ poptart ];
+    mainProgram = "qcp";
   };
-
-  postInstall = ''
-    install -Dm644 $src/qcp/misc/qcp.1 $out/share/man/man1/qcp.1
-    install -Dm644 $src/qcp/misc/qcp_config.5 $out/share/man/man5/qcp_config.5
-    install -Dm644 $src/qcp/misc/20-qcp.conf $out/etc/sysctl.d/20-qcp.conf
-    install -Dm644 $src/qcp/misc/qcp.conf $out/etc/qcp.conf
-    install -Dm644 $src/README.md $out/share/doc/qcp/README.md
-    install -Dm644 $src/LICENSE $out/share/doc/qcp/LICENSE
-  '';
-}
+})

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739206421,
-        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
+        "lastModified": 1748437600,
+        "narHash": "sha256-hYKMs3ilp09anGO7xzfGs3JqEgUqFMnZ8GMAqI6/k04=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
+        "rev": "7282cb574e0607e65224d33be8241eae7cfe0979",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -2,7 +2,7 @@
   description = "The QUIC Copier (qcp) is an experimental high-performance remote file copy utility for long-distance internet connections.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.05";
   };
 
   outputs =


### PR DESCRIPTION
This updates Nix to the 25.05 build, which makes it in sync with some of the upstream nix changes (should close #79). A few of the notes for non-nix people:

* More tests need to be skipped because of sandbox restrictions.
* `checkType` runs the [tests in debug and then does a build with release](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#running-package-tests-running-package-tests)