### PR TITLE
fix: pre-flight configuration validation when not all fields are set

### DIFF
--- a/qcp/src/cli/cli_main.rs
+++ b/qcp/src/cli/cli_main.rs
@@ -172,7 +172,14 @@ async fn run_client(
 ) -> anyhow::Result<bool> {
     let progress =
         MultiProgress::with_draw_target(ProgressDrawTarget::stderr_with_hz(MAX_UPDATE_FPS));
-    config_manager.validate_configuration()?;
+    {
+        // Caution: We haven't applied the system default config at this point, so we don't necessarily have all the fields.
+        // In order to validate what we have, we need to temporarily underlay the system default.
+        let mut temp_mgr = config_manager.clone();
+        temp_mgr.apply_system_default();
+        temp_mgr.validate_configuration()?;
+    }
+
     // this mode may return false
     crate::client_main(config_manager, progress, client_params).await
 }

--- a/qcp/src/config/manager.rs
+++ b/qcp/src/config/manager.rs
@@ -3,11 +3,10 @@
 
 use crate::{
     cli::styles::ColourMode,
-    config::structure::Validatable as _,
     os::{AbstractPlatform as _, Platform},
 };
 
-use super::{ClicolorEnv, Configuration, Configuration_Optional, ssh::ConfigFileError};
+use super::{ClicolorEnv, Configuration, ssh::ConfigFileError};
 
 use anyhow::Result;
 use figment::{Figment, Provider};
@@ -24,7 +23,7 @@ use tracing::{debug, warn};
 ///
 /// Configuration file locations are platform-dependent.
 /// To see what applies on the current platform, run `qcp --config-files`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Manager {
     /// Configuration data
     pub(super) data: Figment,
@@ -239,7 +238,7 @@ impl Manager {
     /// Performs additional validation checks on the fields present in the configuration, as far as possible.
     /// This is only useful when the [`Manager`] holds a [`Configuration`].
     pub fn validate_configuration(&self) -> Result<()> {
-        self.get::<Configuration_Optional>()?.try_validate()
+        self.get::<Configuration>()?.try_validate()
     }
 }
 

--- a/qcp/src/transport.rs
+++ b/qcp/src/transport.rs
@@ -12,7 +12,7 @@ use quinn::{
 use tracing::debug;
 
 use crate::{
-    config::{self, Configuration, Configuration_Optional, Manager, structure::Validatable as _},
+    config::{self, Configuration, Configuration_Optional, Manager},
     protocol::control::{ClientMessageV1, CongestionController},
     util::PortRange,
 };


### PR DESCRIPTION
This was giving a false error that the rx bandwidth was too small.

Removed Validatable trait as it was not very sound, and no longer needed.

closes #123