### PR TITLE
chore: bump nix version to v0.4.2

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,7 +9,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qcp";
-  version = "0.4.1";
+  version = "0.4.2";
 
   # Tags required to fix the binary version
   GITHUB_REF_TYPE = "tag";
@@ -19,11 +19,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "crazyscot";
     repo = "qcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BCUhj60Y4QyE7EFcbfKgkEz8qULD1ONFtdqVo2DJot0=";
+    hash = "sha256-SMu4Laqc9i4U5UgoILlKasWx6E642RscKapTf4WcglM=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-IFIAvFvkvMW/BBC16fP67Hhg616QqcTsF1v+V8Lt1iI=";
+  cargoHash = "sha256-+n7Big7gW4JxKq+cMOEo3slhokhoLnOc9tO7YmtnisU=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -34,36 +34,37 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm644 $src/qcp/misc/qcp.conf $out/etc/qcp.conf
   '';
 
-  checkFlags = [
-    # SSH home directory tests will not work in nix sandbox
-    "--skip=config::ssh::includes::test::home_dir"
-    "--skip=control::process::test::ssh_no_such_host"
-    # Attempts to reach outside of the nix sandbox
-    "--skip=os::unix::test::config_paths"
-    # Permission checks in the sandbox appear to always fail
-    "--skip=session::get::test::permission_denied"
-    # Multiple network tests will fail in sanbox
-    "--skip=util::dns::tests::ipv4"
-    "--skip=util::dns::tests::ipv6"
-    # Tracing attempts to access stdout and angers the sandbox
-    "--skip=util::tracing::test::test_create_layers_with_invalid_level"
-  ]
-  ++ lib.optionals stdenv.buildPlatform.isDarwin [
-    # Skip unix tests on darwin
-    "--skip=control::channel::test::happy_path"
-    "--skip=os::unix::test::test_buffers_gigantic_err"
-    "--skip=os::unix::test::test_buffers_small_ok"
-    "--skip=os::windows::test::test_buffers_gigantic_err"
-    "--skip=os::windows::test::test_buffers_small_ok"
-    "--skip=session::put::test::write_fail_dest_dir_missing"
-    "--skip=session::put::test::write_fail_io_error"
-    "--skip=session::put::test::write_fail_permissions"
-    "--skip=util::socket::test::bind_ipv6"
-    "--skip=util::socket::test::bind_range"
-    "--skip=util::socket::test::set_socket_bufsize_direct"
-    "--skip=util::socket::test::set_udp_buffer_sizes_large_fails"
-    "--skip=util::socket::test::set_udp_buffer_sizes_small_succeeds"
-  ];
+  checkFlags =
+    [
+      # SSH home directory tests will not work in nix sandbox
+      "--skip=config::ssh::includes::test::home_dir"
+      "--skip=control::process::test::ssh_no_such_host"
+      # Attempts to reach outside of the nix sandbox
+      "--skip=os::unix::test::config_paths"
+      # Permission checks in the sandbox appear to always fail
+      "--skip=session::get::test::permission_denied"
+      # Multiple network tests will fail in sanbox
+      "--skip=util::dns::tests::ipv4"
+      "--skip=util::dns::tests::ipv6"
+      # Tracing attempts to access stdout and angers the sandbox
+      "--skip=util::tracing::test::test_create_layers_with_invalid_level"
+    ]
+    ++ lib.optionals stdenv.buildPlatform.isDarwin [
+      # Skip unix tests on darwin
+      "--skip=control::channel::test::happy_path"
+      "--skip=os::unix::test::test_buffers_gigantic_err"
+      "--skip=os::unix::test::test_buffers_small_ok"
+      "--skip=os::windows::test::test_buffers_gigantic_err"
+      "--skip=os::windows::test::test_buffers_small_ok"
+      "--skip=session::put::test::write_fail_dest_dir_missing"
+      "--skip=session::put::test::write_fail_io_error"
+      "--skip=session::put::test::write_fail_permissions"
+      "--skip=util::socket::test::bind_ipv6"
+      "--skip=util::socket::test::bind_range"
+      "--skip=util::socket::test::set_socket_bufsize_direct"
+      "--skip=util::socket::test::set_udp_buffer_sizes_large_fails"
+      "--skip=util::socket::test::set_udp_buffer_sizes_small_succeeds"
+    ];
   checkType = "debug";
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,6 +4,7 @@
   installShellFiles,
   nix-update-script,
   rustPlatform,
+  stdenv,
   versionCheckHook,
 }:
 
@@ -46,6 +47,22 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=util::dns::tests::ipv6"
     # Tracing attempts to access stdout and angers the sandbox
     "--skip=util::tracing::test::test_create_layers_with_invalid_level"
+  ]
+  ++ lib.optionals stdenv.buildPlatform.isDarwin [
+    # Skip unix tests on darwin
+    "--skip=control::channel::test::happy_path"
+    "--skip=os::unix::test::test_buffers_gigantic_err"
+    "--skip=os::unix::test::test_buffers_small_ok"
+    "--skip=os::windows::test::test_buffers_gigantic_err"
+    "--skip=os::windows::test::test_buffers_small_ok"
+    "--skip=session::put::test::write_fail_dest_dir_missing"
+    "--skip=session::put::test::write_fail_io_error"
+    "--skip=session::put::test::write_fail_permissions"
+    "--skip=util::socket::test::bind_ipv6"
+    "--skip=util::socket::test::bind_range"
+    "--skip=util::socket::test::set_socket_bufsize_direct"
+    "--skip=util::socket::test::set_udp_buffer_sizes_large_fails"
+    "--skip=util::socket::test::set_udp_buffer_sizes_small_succeeds"
   ];
   checkType = "debug";
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748437600,
-        "narHash": "sha256-hYKMs3ilp09anGO7xzfGs3JqEgUqFMnZ8GMAqI6/k04=",
+        "lastModified": 1751741127,
+        "narHash": "sha256-t75Shs76NgxjZSgvvZZ9qOmz5zuBE8buUaYD28BMTxg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7282cb574e0607e65224d33be8241eae7cfe0979",
+        "rev": "29e290002bfff26af1db6f64d070698019460302",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This bumps the version. I also added a check for Darwin build platforms that *may* enable building on Macs, but unfortunately I do not have access to one to test.

Quick visual verification of bulid:

```console
[poptart@wabisabi:~/src/qcp-dev/nix]$ nix build
warning: Git tree '/home/poptart/src/qcp-dev' is dirty

[poptart@wabisabi:~/src/qcp-dev/nix]$ ./result/bin/qcp --version
qcp 0.4.2
```