### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,100 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/crazyscot/qcp/compare/v0.4.2...v0.5.0)
+
+### ⛰️ Features
+
+- [**breaking**] Make kernel UDP buffer size configurable - ([963541b](https://github.com/crazyscot/qcp/commit/963541bcd14d273d8f6604e2a8bf48be591f0b00))
+  - **Linux users:** This change may cause warnings about buffer sizes requiring you to reconfigure your sysctls. Run `qcp --help-buffers` and follow its advice.
+- [**breaking**] Remove some infrequently-used CLI short options - ([ecad214](https://github.com/crazyscot/qcp/commit/ecad21429c9dad6ca963bebcf0bafa19c1af0dfe))
+- Add remote PMTU and RTT to --stats output (via ClosedownReport) - ([92d8675](https://github.com/crazyscot/qcp/commit/92d867599f11324f86bfd9bf674f1c298ddbeebd))
+- --preserve option - ([24b8ef2](https://github.com/crazyscot/qcp/commit/24b8ef2943d1e54c310809c6a8b2506b06bba738))
+- Add hidden --remote-trace option - ([9b022a3](https://github.com/crazyscot/qcp/commit/9b022a3448e7b530c584943d6474510a1c232dc0))
+- Add NewReno congestion controller (protocol compat level 2) - ([e865a52](https://github.com/crazyscot/qcp/commit/e865a520140782db0e40b0de81d3d7e7a7ba61c4))
+- Initial, min and max MTU can be configured - ([4919ca4](https://github.com/crazyscot/qcp/commit/4919ca4428f0b8f02e9be311e42080174887862d))
+- Add packet loss detection thresholds as configurable settings - ([37e0f32](https://github.com/crazyscot/qcp/commit/37e0f329fd8415d4191855400c519e63195571e2))
+- _(meta)_ --list-features option - ([c768fc9](https://github.com/crazyscot/qcp/commit/c768fc91a12b1bd8db9b4b011ca4f89ba6a4f00e))
+- _(debug)_ Add the server's idea of MTU and RTT to --remote-debug - ([7161f6d](https://github.com/crazyscot/qcp/commit/7161f6d090cb666d8e43f354b1adb92141a81f44))
+- _(protocol)_ Introduce Variant type - ([908346a](https://github.com/crazyscot/qcp/commit/908346ac36741fe437377049f4b35c45349a6f35))
+- _(protocol)_ Add Compatibility level 2 - ([2d0c1ef](https://github.com/crazyscot/qcp/commit/2d0c1ef2381cdf3f8f373f1a81a273843be08064))
+
+### 🐛 Bug Fixes
+
+- Disallow reading from or writing to non-regular files (device nodes & sockets) - ([b2b036e](https://github.com/crazyscot/qcp/commit/b2b036e18c86132fb4c938633757cea81cac546f))
+- CLI --ssh-config & -S options - ([145bb5d](https://github.com/crazyscot/qcp/commit/145bb5d5ff57d5a975aa9b3aca966971dd171d1e))
+- Use correct system ssh config directory on Windows - ([6ec7001](https://github.com/crazyscot/qcp/commit/6ec70013ab76f11d04becbfbac90caad9a86a0ae))
+- Do not allow RTT to be set to 0 - ([e27baa3](https://github.com/crazyscot/qcp/commit/e27baa31131a2a36443de121350dafe125f40b28))
+- _(cli)_ Remove Markdown mark-up from --help output - ([6362bea](https://github.com/crazyscot/qcp/commit/6362bea74c25cd666e9e3ff8490ab408e833aafb))
+- _(protocol)_ Don't crash on receipt of an unrecognised Status enum - ([baecbaa](https://github.com/crazyscot/qcp/commit/baecbaaf6618e29dfc4d56f1b2411f8c7cf225eb))
+- _(protocol)_ Review and correct enum encoding - ([4a05d4a](https://github.com/crazyscot/qcp/commit/4a05d4a5f6c8d4d6cfd5995abff14c42b3ab1573))
+- _(test)_ DNS lookup sometimes failed on Windows CI - ([79ec010](https://github.com/crazyscot/qcp/commit/79ec0102e3cc84aa304ef2af6117df23ec223008))
+- _(ui)_ Don't report a peak rate of 0B/s on really fast transfers - ([d90364b](https://github.com/crazyscot/qcp/commit/d90364bb6b887c10a45552f9063033b287f13d90))
+
+### 📚 Documentation
+
+- Autogenerate CLI HTML doc - ([1163169](https://github.com/crazyscot/qcp/commit/11631697b41d772e1461393fbecdffb3d20164d9))
+- Tidy/polish Rust docs - ([c639856](https://github.com/crazyscot/qcp/commit/c639856c7982fdd5ee5c3b01375d87d58c01c077))
+
+### ⚡ Performance
+
+- Add direction-of-travel indicator to ClientMessage - ([9c4b2ed](https://github.com/crazyscot/qcp/commit/9c4b2ed686115a7ee3248922aa335530d2f5a319))
+- Set initial_rtt as 2x expected RTT - ([4866a98](https://github.com/crazyscot/qcp/commit/4866a98e65edb21fd71646f73835607d6d1f6ff5))
+- Use a larger send window, in line with Quinn's default tuning - ([03f6161](https://github.com/crazyscot/qcp/commit/03f6161a9a690b96e900a695613868d2e935e9bf))
+
+### 🎨 Styling
+
+- Improve consistency of control channel debug output - ([cfcd6a6](https://github.com/crazyscot/qcp/commit/cfcd6a6287b982b429f770dced6a4503083f5401))
+- Implement Display for TaggedData - ([1e10293](https://github.com/crazyscot/qcp/commit/1e1029352c8f695e1ae4f2a98aa58d694272a6aa))
+- Reduce excess verbiage when reporting FileNotFound or IncorrectPermissions errors - ([35d53ce](https://github.com/crazyscot/qcp/commit/35d53ce539a73c2652d999e8c3e8bb5fdbf3314e))
+- Make server-mode output more easily distinguishable - ([90d9659](https://github.com/crazyscot/qcp/commit/90d9659573130f0c926ec53e7a52ce749022a402))
+
+### 🧪 Testing
+
+- Add an integration test that simulates MITM attacks - ([f5e28f6](https://github.com/crazyscot/qcp/commit/f5e28f6fc21bd47bd024bef2c37946fc861c6e79))
+- Move some CLI tests into integration test area - ([8fe67f9](https://github.com/crazyscot/qcp/commit/8fe67f99eb85ac1936cb01e4772943610998fcb7))
+- Add wire marshalling regression tests for current protocol messages - ([51413ec](https://github.com/crazyscot/qcp/commit/51413eca7d0c8ad17b18ee85fda53923584c4149))
+- Fill-in coverage in transport.rs - ([cef4f47](https://github.com/crazyscot/qcp/commit/cef4f47be71b0e0d87be977a55688d55131368fb))
+- Fix compiler warnings on apple & windows - ([f3e90a2](https://github.com/crazyscot/qcp/commit/f3e90a232c4c84ad94455db0e30b24e83983c069))
+- Exercise the main CLI modes and parser - ([eda8d12](https://github.com/crazyscot/qcp/commit/eda8d1270833397c5e38810b606f809eab852b3d))
+- Add unit tests for the informational main modes - ([07fd94f](https://github.com/crazyscot/qcp/commit/07fd94fcacbcdd67db69e46ed2818f558540bae3))
+- Refactor server_main, add a unit test - ([ef7f8c3](https://github.com/crazyscot/qcp/commit/ef7f8c375cad93f7e4ab346f147530410f211a7c))
+- Refactoring server connection.handle_incoming, add a unit test - ([39be470](https://github.com/crazyscot/qcp/commit/39be470f2c0065b2995f4f5d521c720cb3d34c64))
+- Add unit tests for server::connection_info, server::stream - ([72a0812](https://github.com/crazyscot/qcp/commit/72a081264e2f1a3b606d84f60173a567d87be4b5))
+- Use pretty_assertions - ([12e41b6](https://github.com/crazyscot/qcp/commit/12e41b6d90eb104ffd1461bd34f9f00ee27c3f44))
+- _(windows)_ Improve Windows config file path checks - ([bd42133](https://github.com/crazyscot/qcp/commit/bd42133ff86c775354daa1af727831a1d78a7840))
+
+### 🏗️ Build, packaging & CI
+
+- Rename output artifact names to be more user friendly - ([ec40671](https://github.com/crazyscot/qcp/commit/ec406710e9e3ce8a9442776e5d2e4a8bbc6e3ad9))
+- Scaffolding & feature to expose internal test helpers for use by qcp-unsafe-tests - ([e947393](https://github.com/crazyscot/qcp/commit/e94739351b8ded5fd20c9dca6653e122229755b7))
+- Disable tests where they don't work on mingw cross-compiles - ([064a4c9](https://github.com/crazyscot/qcp/commit/064a4c998c985640006691dd4f0fe447e25be759))
+
+### ⚙️ Miscellaneous Tasks
+
+- _(ci,docs)_ Fix cargo doc --document-private items, add it to CI checks - ([8113e84](https://github.com/crazyscot/qcp/commit/8113e8496d2b6c5ddffa46af009e1bf18295b78e))
+- Use strum_macros:: consistently - ([8f1a39b](https://github.com/crazyscot/qcp/commit/8f1a39b2eca8f770b84238b5771ed07c941b4e82))
+- Use if cfg!() instead of cfg_if! where possible - ([a787101](https://github.com/crazyscot/qcp/commit/a787101bf17127384c922e7c53b832c4294cbc16))
+- Update template qcp.conf - ([594d8d7](https://github.com/crazyscot/qcp/commit/594d8d75626797f79b3923470f1c99429413a733))
+- Tidy `os` module exports, OS notes - ([36dbbac](https://github.com/crazyscot/qcp/commit/36dbbac11d61b3962ad79c4f81947176ed2bf6d0))
+
+### 🚜 Refactor
+
+- _(test)_ Make the test suite cross-platform - ([47ba293](https://github.com/crazyscot/qcp/commit/47ba293ba65a399d3ba81effdab36d697cf64c5d))
+- Add ergonomic constructors DataTag::with_unsigned,with_signed - ([af67621](https://github.com/crazyscot/qcp/commit/af67621b5c938b9cbcfafea6f95dce030ff2515e))
+- Improve ThroughputMode consistency - ([88e4f3e](https://github.com/crazyscot/qcp/commit/88e4f3e4ee9c21ef586ccb3a8c90d79237bb8390))
+- Add FindTag helper trait for Vec<TaggedData<>> - ([fb23c39](https://github.com/crazyscot/qcp/commit/fb23c39e96a86f937f317a74a342d6c475ba6356))
+- Use derive_more::{Debug,Display} in control protocol - ([a179046](https://github.com/crazyscot/qcp/commit/a1790465954e60ba515ffbf6fde3734d666571b6))
+- Move DataTag up a level so it can be common to both protocols - ([8d51685](https://github.com/crazyscot/qcp/commit/8d51685767cdffe169deb8a2dbc2b739959e790e))
+- Split up client main_loop a bit more for readability & testability - ([a0e4b6c](https://github.com/crazyscot/qcp/commit/a0e4b6c59c33d24094ba0feb961cf76952503bff))
+- Check_response() makes more sense as a function of Response - ([e24146f](https://github.com/crazyscot/qcp/commit/e24146ff32baaaaea2ece1eb1b4a8ab9b7496390))
+- Client_main for testability and simplicity ([37620bb](https://github.com/crazyscot/qcp/commit/37620bbde0dcacb7d5a7fdec7c9c8a8a07265fb2)) ([f175d24](https://github.com/crazyscot/qcp/commit/f175d24666025bcb8e721ca53c1688173a58e654))
+- Separate out process::Ssh into a generic ProcessWrapper and the ssh-specific parts - ([ecd1196](https://github.com/crazyscot/qcp/commit/ecd1196d855eb64000704e9aa5a56aea4a51b880))
+- Tracing::setup() arguments - ([79faa48](https://github.com/crazyscot/qcp/commit/79faa48c30fa4c4b9aa00d26fa7f74931ca5d88c))
+- Split apart server.rs for testability - ([31927fb](https://github.com/crazyscot/qcp/commit/31927fbc376e68ef9cc795cf4264cd597e62f616))
+- Setup_tracing becomes a struct with a trait - ([e2a782f](https://github.com/crazyscot/qcp/commit/e2a782fd624dbd7bcfdc36a742fa5fd1426df08d))
+- Use clap to create MainMode enum - ([49781fa](https://github.com/crazyscot/qcp/commit/49781fa1d2e2c918b643e7368bebe6f639fb6fe8))
+
 ## [0.4.2](https://github.com/crazyscot/qcp/compare/v0.4.1...v0.4.2)
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,22 +73,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
 name = "block-buffer"
@@ -223,9 +223,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "bytes"
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
 dependencies = [
  "shlex",
 ]
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -601,7 +601,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "serde",
- "thiserror 2.0.14",
+ "thiserror",
 ]
 
 [[package]]
@@ -767,9 +767,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -960,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags",
  "libc",
@@ -976,9 +976,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "littertray"
@@ -991,7 +991,7 @@ dependencies = [
  "document-features",
  "rustversion",
  "tempfile",
- "thiserror 2.0.14",
+ "thiserror",
  "tokio",
 ]
 
@@ -1345,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "qcp"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1426,7 +1426,7 @@ dependencies = [
  "strum_macros",
  "tabled",
  "tempfile",
- "thiserror 2.0.14",
+ "thiserror",
  "tokio",
  "tokio-test",
  "tracing",
@@ -1478,7 +1478,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.14",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1499,7 +1499,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.14",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1536,9 +1536,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
@@ -1587,13 +1587,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.14",
+ "thiserror",
 ]
 
 [[package]]
@@ -1662,9 +1662,9 @@ checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -1687,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
@@ -1712,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1723,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -1842,9 +1842,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -1971,9 +1971,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2019,12 +2019,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2044,38 +2044,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "80d76d3f064b981389ecb4b6b7f45a0bf9fdac1d5b9204c7bd6714fecc302850"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
-dependencies = [
- "thiserror-impl 2.0.14",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
+checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2181,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ae868b5a0f67631c14589f7e250c1ea2c574ee5ba21c6c8dd4b1485705a5a1"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap",
  "serde",
@@ -2222,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow",
 ]
@@ -2350,9 +2330,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -2639,7 +2619,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2660,10 +2640,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2790,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "x509-certificate"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57b9f8bcae7c1f36479821ae826d75050c60ce55146fd86d3553ed2573e2762"
+checksum = "ca9eb9a0c822c67129d5b8fcc2806c6bc4f50496b420825069a440669bcfbf7f"
 dependencies = [
  "bcder",
  "bytes",
@@ -2803,7 +2784,7 @@ dependencies = [
  "ring",
  "signature",
  "spki",
- "thiserror 1.0.69",
+ "thiserror",
  "zeroize",
 ]
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,27 @@ high-performance remote file copy utility for long-distance internet connections
 
 ### News
 
+- **(New in 0.5)**
+  - The default UDP buffer size is now 4MB. _This may cause warnings until you have updated your sysctl.conf._
+  - New features: `--preserve`; `NewReno` congestion controller; `--list-features` meta feature
+  - New tuning options: UDP buffer size, MTU, packet loss detection thresholds
+  - Removed some infrequently-used CLI short options
 - **(New in 0.4)**
   - Added builds for [OSX](https://docs.rs/qcp/latest/qcp/doc/osx/index.html), [Windows](https://docs.rs/qcp/latest/qcp/doc/windows/index.html) and BSD
   - New features: Explicit username with `-l <login-name>`; ssh subsystem mode
 - **(New in 0.3)**
   - Negotiate transport setting by combining configuration from both sides
   - Protocol encoding changed to [BARE], removing the dependency on capnp.
+  - **0.3 was a total compatibility break** with earlier versions.
 
 For a full list of changes, see the [changelog].
+
+#### Compatibility
+
+The protocol has been designed to be backwards and forwards compatible (since the 0.3 compatibility break).
+
+Binaries which are different versions can interoperate, provided both sides support the required features.
+If you find they can't, or one side crashes, please report a bug.
 
 #### Platform support status
 
@@ -43,9 +56,9 @@ At the time of writing, qcp has only been tested with the OpenSSH server and cli
 | OpenBSD        |                  | Ought to be buildable\*               |
 | Windows 11     | x86_64           | Tested                                |
 
-*\_Note that the *BSD family are not tier 1 Rust platforms, so there is no guarantee that things will work properly. As of 31/3/25 some of these platforms have cross-compilation issues; I haven't tried native compilation.\_
+\* _Note that the \*BSD family are not tier 1 Rust platforms, so there is no guarantee that things will work properly. As of 31/3/25 some of these platforms have cross-compilation issues; I haven't tried native compilation._
 
-\*\* _The binaries in the tarballs are the exact same binaries found in the Debian/Ubuntu packages. They are static-linked, independent of kernel and libc._
+\*\* _The binaries in the tarballs are the exact same binaries found in the Debian/Ubuntu packages. They are static linked, independent of libc versions, should work with any recent kernel._
 
 ## 🧰 Getting Started
 
@@ -59,9 +72,11 @@ At the time of writing, qcp has only been tested with the OpenSSH server and cli
       of its choice of port number.
 - Install the `qcp` binary on both machines. It needs to be in your `PATH` on the remote machine,
   or you need to set up `SshSubsystem` mode.
-  - Check the platform-specific notes: [OSX](https://docs.rs/qcp/latest/qcp/doc/osx/index.html),
-    [Linux/other Unix](https://docs.rs/qcp/latest/qcp/doc/unix/index.html),
-    [Windows](https://docs.rs/qcp/latest/qcp/doc/windows/index.html)
+  - Check the platform-specific notes:
+    [OSX](https://docs.rs/qcp/latest/qcp/os/osx/index.html),
+    [Linux/other Unix](https://docs.rs/qcp/latest/qcp/os/unix/index.html),
+    [Windows](https://docs.rs/qcp/latest/qcp/os/windows/index.html)
+  - If upgrading, remember to upgrade both machines if you want to take advantage of newer protocol features.
 - Try it out! Use `qcp` where you would `scp`, e.g. `qcp myfile some-server:some-directory/`
 - Browse the tuning options in [Configuration](https://docs.rs/qcp/latest/qcp/struct.Configuration.html)
 - Set up a [config](config) file that tunes for your network connection. (You might find the `--stats` option useful when experimenting.)
@@ -74,8 +89,8 @@ These can be found on the [latest release](https://github.com/crazyscot/qcp/rele
 | --------------- | --------------- | ------------------------------------------------------------------------------- |
 | Debian & Ubuntu | x86_64, aarch64 | Deb packages                                                                    |
 | Other Linux     | x86_64, aarch64 | Use the unknown-linux-musl tarballs (they are cross-platform, static linked)    |
-| Nix             | \*              | Flakes are provided: `nix shell 'github:crazyscot/qcp?dir=nix'`                 |
-| NixOS           | \*              | In progress; refer to [pr#361923](https://github.com/NixOS/nixpkgs/pull/361923) |
+| Nix             | all             | Flakes are provided: `nix shell 'github:crazyscot/qcp?dir=nix'`                 |
+| NixOS           | all             | In progress; refer to [pr#361923](https://github.com/NixOS/nixpkgs/pull/361923) |
 | OSX             | x86_64, aarch64 | Tarball (code signing TBD)                                                      |
 | Windows         | x86_64          | Zipfile (code signing TBD)                                                      |
 
@@ -193,7 +208,7 @@ Bug reports and feature requests are welcome, please use the [issue] tracker.
 
 🚧 If you're thinking of contributing code, please read [CONTRIBUTING.md].
 
-#### Help wanted: MacOS/BSD/Windows
+#### Help wanted: Non-Linux platforms
 
 I'd particularly welcome performance reports here, as they are not platforms I use regularly.
 
@@ -201,19 +216,23 @@ I'd particularly welcome performance reports here, as they are not platforms I u
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 2.0.0.
 
+**We also consider a change to be a breaking if a user might have to change something they do,** even if the API remains compatible.
+
 In its initial experimental phase, the major number will be kept at 0.
 Breaking changes will be noted in the [changelog] and will trigger a minor version bump.
 
-The project will move to version 1.x when the protocol has stabilised. After 1.0, breaking changes will trigger a major version bump.
+Since 0.3 the protocol has been designed to be forwards and backwards compatible. In other words any two versions should be able to interoperate, provided they both support the required features.
+
+The project will move to version 1.x when the protocol has stabilised.
 
 ### Unsafe Rust
 
 Any uses of unsafe Rust will be kept to a bare minimum and carefully reviewed.
 
+Unsafe Rust is currently forbidden in the main qcp crate.
+
 Test code (protected by `#[cfg(test)]`) may be exempted from this policy.
 However we prefer that unsafe test code lives in the subcrate `qcp-unsafe-tests`.
-
-Therefore, unsafe Rust is currently forbidden in the main qcp crate.
 
 ## 💸 Supporting the project
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 This project is currently in an experimental phase, signified by major version number `0`.
 
-| Versions | Supported                 |
-| :------: | ------------------------- |
-|  0.4.x   | :white_check_mark: Active |
-|  0.3.x   | Sunset                    |
-|  < 0.3   | :x: No longer maintained  |
+| Versions | Supported                              |
+| :------: | -------------------------------------- |
+|  0.5.x   | :white_check_mark: Active              |
+|  0.4.x   | :sunset: Sunset (important fixes only) |
+|  < 0.4   | :x: No longer maintained               |
 
 ## Reporting a Vulnerability
 

--- a/qcp/Cargo.toml
+++ b/qcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "qcp"
 description = "Secure remote file copy utility which uses the QUIC protocol over UDP"
 rust-version = "1.85.0"
-version = "0.4.2"
+version = "0.5.0"
 edition.workspace = true
 authors = ["Ross Younger <qcp@crazyscot.com>"]
 license = "AGPL-3.0-or-later"
@@ -27,7 +27,7 @@ unstable-test-helpers = []
 anstream = { workspace = true }
 anstyle = { workspace = true }
 anyhow = { workspace = true }
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 bytes = "1.10.1"
 cfg-if = { workspace = true }
 clap = { workspace = true }
@@ -53,6 +53,7 @@ gethostname = "1.0.2"
 glob = "0.3.3"
 heck = "0.5.0"
 hex = "0.4.3"
+# homedir pinned to 0.3.4 for now, as 0.3.5 requires a more recent MSRV than ours
 homedir = "=0.3.4"
 human-repr = "1.1.0"
 indicatif = { version = "0.18.0", features = ["tokio"] }
@@ -78,7 +79,7 @@ struct-field-names-as-array = "0.3.0"
 strum = { version = "0.27.2", features = ["derive"] }
 strum_macros = "0.27.2"
 tabled = "0.20.0"
-thiserror = "2.0.14"
+thiserror = "2.0.15"
 tokio = { workspace = true }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "chrono"] }
@@ -101,7 +102,7 @@ serde_json = "1.0.142"
 serde_test = "1.0.177"
 tempfile = { workspace = true }
 tokio-test = "0.4.4"
-x509-certificate = "0.24.0"
+x509-certificate = "0.25.0"
 
 [lints.rust]
 dead_code = "warn"

--- a/qcp/src/lib.rs
+++ b/qcp/src/lib.rs
@@ -55,11 +55,10 @@
 //!       of its choice of port number.
 //! * Install the `qcp` binary on both machines. It needs to be in your `PATH` on the remote machine,
 //!   or you need to set up `SshSubsystem` mode.
-//!   * Check the platform-specific notes: [OSX](https://docs.rs/qcp/latest/qcp/doc/osx/index.html),
-//!     [Linux/other Unix](https://docs.rs/qcp/latest/qcp/doc/unix/index.html),
-//!     [Windows](https://docs.rs/qcp/latest/qcp/doc/windows/index.html)
+//!   * Check the platform-specific notes:
+//!     🍎 [OSX](os::osx), 🐧 [Linux & other Unix](os::unix), 🪟 [Windows](os::windows)
 //! * Try it out! Use `qcp` where you would `scp`, e.g. `qcp myfile some-server:some-directory/`
-//! * Browse the tuning options in [Configuration](https://docs.rs/qcp/latest/qcp/struct.Configuration.html)
+//! * Browse the tuning options in [Configuration]
 //! * Set up a [config](config) file that tunes for your network connection. (You might find the `--stats` option useful when experimenting.)
 //!
 //! ## 📖 How it works


### PR DESCRIPTION



## 🤖 New release

* `qcp`: 0.4.2 -> 0.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/crazyscot/qcp/compare/v0.4.2...v0.5.0)

### ⛰️ Features

- *(debug)* Add the server's idea of MTU and RTT to --remote-debug - ([7161f6d](https://github.com/crazyscot/qcp/commit/7161f6d090cb666d8e43f354b1adb92141a81f44))
- *(proto)* Introduce Variant type - ([908346a](https://github.com/crazyscot/qcp/commit/908346ac36741fe437377049f4b35c45349a6f35))
- *(protocol)* Add CompatibilityLevel::V2 - ([2d0c1ef](https://github.com/crazyscot/qcp/commit/2d0c1ef2381cdf3f8f373f1a81a273843be08064))
- Add remote PMTU and RTT to --stats output (via ClosedownReport) - ([92d8675](https://github.com/crazyscot/qcp/commit/92d867599f11324f86bfd9bf674f1c298ddbeebd))
- --preserve option - ([24b8ef2](https://github.com/crazyscot/qcp/commit/24b8ef2943d1e54c310809c6a8b2506b06bba738))
- Add hidden --remote-trace option - ([9b022a3](https://github.com/crazyscot/qcp/commit/9b022a3448e7b530c584943d6474510a1c232dc0))
- Add NewReno congestion controller (protocol compat level 2) - ([e865a52](https://github.com/crazyscot/qcp/commit/e865a520140782db0e40b0de81d3d7e7a7ba61c4))
- Initial, min and max MTU can be configured - ([4919ca4](https://github.com/crazyscot/qcp/commit/4919ca4428f0b8f02e9be311e42080174887862d))
- Add packet loss detection thresholds as configurable settings - ([37e0f32](https://github.com/crazyscot/qcp/commit/37e0f329fd8415d4191855400c519e63195571e2))
- [**breaking**] Make kernel UDP buffer size configurable - ([963541b](https://github.com/crazyscot/qcp/commit/963541bcd14d273d8f6604e2a8bf48be591f0b00))
- --list-features option - ([c768fc9](https://github.com/crazyscot/qcp/commit/c768fc91a12b1bd8db9b4b011ca4f89ba6a4f00e))

### 🐛 Bug Fixes

- *(cli)* Remove Markdown mark-up from --help output - ([6362bea](https://github.com/crazyscot/qcp/commit/6362bea74c25cd666e9e3ff8490ab408e833aafb))
- *(protocol)* Don't crash on receipt of an unrecognised Status enum - ([baecbaa](https://github.com/crazyscot/qcp/commit/baecbaaf6618e29dfc4d56f1b2411f8c7cf225eb))
- *(protocol)* Review and correct enum encoding - ([4a05d4a](https://github.com/crazyscot/qcp/commit/4a05d4a5f6c8d4d6cfd5995abff14c42b3ab1573))
- *(test)* DNS lookup sometimes failed on Windows CI - ([79ec010](https://github.com/crazyscot/qcp/commit/79ec0102e3cc84aa304ef2af6117df23ec223008))
- *(ui)* Don't report a peak rate of 0B/s on really fast transfers - ([d90364b](https://github.com/crazyscot/qcp/commit/d90364bb6b887c10a45552f9063033b287f13d90))
- Disallow reading from or writing to non-regular files (device nodes & sockets) - ([b2b036e](https://github.com/crazyscot/qcp/commit/b2b036e18c86132fb4c938633757cea81cac546f))
- CLI --ssh-config & -S options - ([145bb5d](https://github.com/crazyscot/qcp/commit/145bb5d5ff57d5a975aa9b3aca966971dd171d1e))
- Use correct system ssh config directory on Windows - ([6ec7001](https://github.com/crazyscot/qcp/commit/6ec70013ab76f11d04becbfbac90caad9a86a0ae))
- Do not allow RTT to be set to 0 - ([e27baa3](https://github.com/crazyscot/qcp/commit/e27baa31131a2a36443de121350dafe125f40b28))

### 📚 Documentation

- Autogenerate CLI HTML doc - ([1163169](https://github.com/crazyscot/qcp/commit/11631697b41d772e1461393fbecdffb3d20164d9))
- Tidy/polish Rust docs - ([c639856](https://github.com/crazyscot/qcp/commit/c639856c7982fdd5ee5c3b01375d87d58c01c077))

### ⚡ Performance

- Add direction-of-travel indicator to ClientMessage - ([9c4b2ed](https://github.com/crazyscot/qcp/commit/9c4b2ed686115a7ee3248922aa335530d2f5a319))
- Set initial_rtt as 2x expected RTT - ([4866a98](https://github.com/crazyscot/qcp/commit/4866a98e65edb21fd71646f73835607d6d1f6ff5))
- Use a larger send window, in line with Quinn's default tuning - ([03f6161](https://github.com/crazyscot/qcp/commit/03f6161a9a690b96e900a695613868d2e935e9bf))

### 🎨 Styling

- Improve consistency of control channel debug output - ([cfcd6a6](https://github.com/crazyscot/qcp/commit/cfcd6a6287b982b429f770dced6a4503083f5401))
- Implement Display for TaggedData - ([1e10293](https://github.com/crazyscot/qcp/commit/1e1029352c8f695e1ae4f2a98aa58d694272a6aa))
- Reduce excess verbiage when reporting FileNotFound or IncorrectPermissions errors - ([35d53ce](https://github.com/crazyscot/qcp/commit/35d53ce539a73c2652d999e8c3e8bb5fdbf3314e))
- Make server-mode output more easily distinguishable - ([90d9659](https://github.com/crazyscot/qcp/commit/90d9659573130f0c926ec53e7a52ce749022a402))

### 🧪 Testing

- *(skip)* Fix sporadic integration test failure (race condition) - ([ca33cdb](https://github.com/crazyscot/qcp/commit/ca33cdb74b064ebfd52dbe4897993e12bb25688f))
- *(windows)* Improve Windows config file path checks - ([bd42133](https://github.com/crazyscot/qcp/commit/bd42133ff86c775354daa1af727831a1d78a7840))
- Add an integration test that simulates MITM attacks - ([f5e28f6](https://github.com/crazyscot/qcp/commit/f5e28f6fc21bd47bd024bef2c37946fc861c6e79))
- Move some CLI tests into integration test area - ([8fe67f9](https://github.com/crazyscot/qcp/commit/8fe67f99eb85ac1936cb01e4772943610998fcb7))
- Add wire marshalling regression tests for current protocol messages - ([51413ec](https://github.com/crazyscot/qcp/commit/51413eca7d0c8ad17b18ee85fda53923584c4149))
- Fill-in coverage in transport.rs - ([cef4f47](https://github.com/crazyscot/qcp/commit/cef4f47be71b0e0d87be977a55688d55131368fb))
- Fix compiler warnings on apple & windows - ([f3e90a2](https://github.com/crazyscot/qcp/commit/f3e90a232c4c84ad94455db0e30b24e83983c069))
- Exercise the main CLI modes and parser - ([eda8d12](https://github.com/crazyscot/qcp/commit/eda8d1270833397c5e38810b606f809eab852b3d))
- Add unit tests for the informational main modes - ([07fd94f](https://github.com/crazyscot/qcp/commit/07fd94fcacbcdd67db69e46ed2818f558540bae3))
- Refactor server_main, add a unit test - ([ef7f8c3](https://github.com/crazyscot/qcp/commit/ef7f8c375cad93f7e4ab346f147530410f211a7c))
- Refactoring server connection.handle_incoming, add a unit test - ([39be470](https://github.com/crazyscot/qcp/commit/39be470f2c0065b2995f4f5d521c720cb3d34c64))
- Add unit tests for server::connection_info, server::stream - ([72a0812](https://github.com/crazyscot/qcp/commit/72a081264e2f1a3b606d84f60173a567d87be4b5))
- Use pretty_assertions - ([12e41b6](https://github.com/crazyscot/qcp/commit/12e41b6d90eb104ffd1461bd34f9f00ee27c3f44))

### 🏗️ Build, packaging & CI

- Rename output artifact names to be more user friendly - ([ec40671](https://github.com/crazyscot/qcp/commit/ec406710e9e3ce8a9442776e5d2e4a8bbc6e3ad9))
- Scaffolding & feature to expose internal test helpers for use by qcp-unsafe-tests - ([e947393](https://github.com/crazyscot/qcp/commit/e94739351b8ded5fd20c9dca6653e122229755b7))
- Disable tests where they don't work on mingw cross-compiles - ([064a4c9](https://github.com/crazyscot/qcp/commit/064a4c998c985640006691dd4f0fe447e25be759))

### ⚙️ Miscellaneous Tasks

- *(ci,docs)* Fix cargo doc --document-private items, add it to CI checks - ([8113e84](https://github.com/crazyscot/qcp/commit/8113e8496d2b6c5ddffa46af009e1bf18295b78e))
- *(test)* Remove unstable non-portable test - ([cbecf88](https://github.com/crazyscot/qcp/commit/cbecf8872111ea8da7514956d025979a52e1e92f))
- *(test)* Deduplicate test_buffers_* - ([26379b7](https://github.com/crazyscot/qcp/commit/26379b7795fea666a031554e5f5993bf6d4d1024))
- Introduce SystemTime extension trait - ([abdd45a](https://github.com/crazyscot/qcp/commit/abdd45a2d0377b2fb8066bb6bece657fc4b8d841))
- Rename CompatibilityLevel to Compatibility - ([f1e7a9e](https://github.com/crazyscot/qcp/commit/f1e7a9e381629312e1efe2e95b7fd457b20d8fa7))
- [**breaking**] Remove some infrequently-used CLI short options - ([ecad214](https://github.com/crazyscot/qcp/commit/ecad21429c9dad6ca963bebcf0bafa19c1af0dfe))
- Use strum_macros:: consistently - ([8f1a39b](https://github.com/crazyscot/qcp/commit/8f1a39b2eca8f770b84238b5771ed07c941b4e82))
- Pass protocol compat level through to transport config setup - ([d57b7e3](https://github.com/crazyscot/qcp/commit/d57b7e381862630babd8a6b904a7eee08e41cf78))
- Rename control::COMPATIBILITY_LEVEL and ControlChannel.compat - ([6c1911e](https://github.com/crazyscot/qcp/commit/6c1911e8ae4e697da8098b664a53aadd3bb78a08))
- Clippy warnings in rust 1.88 - ([a5ca9a5](https://github.com/crazyscot/qcp/commit/a5ca9a57e97514d0cc78204799ba4b04d144e080))
- Use if cfg!() instead of cfg_if! where possible - ([a787101](https://github.com/crazyscot/qcp/commit/a787101bf17127384c922e7c53b832c4294cbc16))
- Update template qcp.conf for recent changes - ([594d8d7](https://github.com/crazyscot/qcp/commit/594d8d75626797f79b3923470f1c99429413a733))
- Tidy `os` module exports, OS notes - ([36dbbac](https://github.com/crazyscot/qcp/commit/36dbbac11d61b3962ad79c4f81947176ed2bf6d0))
- Promote TABLE_STYLE into the styles module - ([8ff74b8](https://github.com/crazyscot/qcp/commit/8ff74b8fecd97214695d47e9ba61f19cd3eb3f30))

### 🚜 Refactor

- *(protocol)* Store CompatibilityLevel internally as an enum - ([d8ea8ef](https://github.com/crazyscot/qcp/commit/d8ea8ef555466082ac51a8864b05e810a9bd8677))
- *(test)* Make the test suite cross-platform - ([47ba293](https://github.com/crazyscot/qcp/commit/47ba293ba65a399d3ba81effdab36d697cf64c5d))
- Add ergonomic constructors DataTag::with_unsigned,with_signed - ([af67621](https://github.com/crazyscot/qcp/commit/af67621b5c938b9cbcfafea6f95dce030ff2515e))
- Improve ThroughputMode consistency - ([88e4f3e](https://github.com/crazyscot/qcp/commit/88e4f3e4ee9c21ef586ccb3a8c90d79237bb8390))
- Add FindTag helper trait for Vec<TaggedData<>> - ([fb23c39](https://github.com/crazyscot/qcp/commit/fb23c39e96a86f937f317a74a342d6c475ba6356))
- Use derive_more::{Debug,Display} in control protocol - ([a179046](https://github.com/crazyscot/qcp/commit/a1790465954e60ba515ffbf6fde3734d666571b6))
- Move DataTag up a level so it can be common to both protocols - ([8d51685](https://github.com/crazyscot/qcp/commit/8d51685767cdffe169deb8a2dbc2b739959e790e))
- Split up client main_loop a bit more for readability & testability - ([a0e4b6c](https://github.com/crazyscot/qcp/commit/a0e4b6c59c33d24094ba0feb961cf76952503bff))
- Check_response() makes more sense as a function of Response - ([e24146f](https://github.com/crazyscot/qcp/commit/e24146ff32baaaaea2ece1eb1b4a8ab9b7496390))
- Client_main for testability (and simplicity!), part 2 - ([f175d24](https://github.com/crazyscot/qcp/commit/f175d24666025bcb8e721ca53c1688173a58e654))
- Separate out process::Ssh into a generic ProcessWrapper and the ssh-specific parts - ([ecd1196](https://github.com/crazyscot/qcp/commit/ecd1196d855eb64000704e9aa5a56aea4a51b880))
- Client_main for testability, part 1 - ([37620bb](https://github.com/crazyscot/qcp/commit/37620bbde0dcacb7d5a7fdec7c9c8a8a07265fb2))
- Tracing::setup() arguments - ([79faa48](https://github.com/crazyscot/qcp/commit/79faa48c30fa4c4b9aa00d26fa7f74931ca5d88c))
- Split apart server.rs for testability - ([31927fb](https://github.com/crazyscot/qcp/commit/31927fbc376e68ef9cc795cf4264cd597e62f616))
- Setup_tracing becomes a struct with a trait - ([e2a782f](https://github.com/crazyscot/qcp/commit/e2a782fd624dbd7bcfdc36a742fa5fd1426df08d))
- Use clap to create MainMode enum - ([49781fa](https://github.com/crazyscot/qcp/commit/49781fa1d2e2c918b643e7368bebe6f639fb6fe8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).