### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/crazyscot/qcp/compare/v0.5.0...v0.5.1)
+
+### 🐛 Bug Fixes
+
+- Debian postinst script edge case - ([4be84d9](https://github.com/crazyscot/qcp/commit/4be84d99b0c5d7282c525629eabf46baae0ba91f))
+
+
 ## [0.5.0](https://github.com/crazyscot/qcp/compare/v0.4.2...v0.5.0)
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "qcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/qcp/Cargo.toml
+++ b/qcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "qcp"
 description = "Secure remote file copy utility which uses the QUIC protocol over UDP"
 rust-version = "1.85.0"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 authors = ["Ross Younger <qcp@crazyscot.com>"]
 license = "AGPL-3.0-or-later"

--- a/qcp/debian/postinst
+++ b/qcp/debian/postinst
@@ -75,4 +75,6 @@ fi
 
 # We just dropped a config fragment into /etc/ssh/sshd_config.d.
 # Reload the ssh service, if it's present.
-[ ! -f /lib/systemd/system/ssh.service ] || systemctl reload ssh
+#   #154: Failure is not an error in this script; if ssh is inactive or masked,
+#   reload fails, which we don't worry about.
+[ ! -f /lib/systemd/system/ssh.service ] || systemctl reload ssh || true


### PR DESCRIPTION



## 🤖 New release

* `qcp`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/crazyscot/qcp/compare/v0.5.0...v0.5.1)

### 🐛 Bug Fixes

- Debian postinst script edge case - ([4be84d9](https://github.com/crazyscot/qcp/commit/4be84d99b0c5d7282c525629eabf46baae0ba91f))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).