### PR TITLE
chore: bump nix version to v0.6.0 & update to nixpkgs to 25.11

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,7 +10,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qcp";
-  version = "0.5.2";
+  version = "0.6.0";
 
   # Tags required to fix the binary version
   GITHUB_REF_TYPE = "tag";
@@ -20,11 +20,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "crazyscot";
     repo = "qcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7s/xEbheRI+8j73CKy8CDfy6MKZkEhQDt3KWowbPtjc=";
+    hash = "sha256-E5pQoO0uUK+G/ghEv50ELJDHv/QNP81WMPGtGdKN5qU=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-CJh04eaEHvm42x5nR/uDvKYiWGfVFBwvkwriyC3w6dg=";
+  cargoHash = "sha256-4kMYYFJS0TxuvHMxiB/L58LUjnxSbUoF9DhLTYv/RUc=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751741127,
-        "narHash": "sha256-t75Shs76NgxjZSgvvZZ9qOmz5zuBE8buUaYD28BMTxg=",
+        "lastModified": 1764406085,
+        "narHash": "sha256-CYbMp8hwuOf4umokSNp+t1s4Hjd4vxXq4S5CD+xvgNs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29e290002bfff26af1db6f64d070698019460302",
+        "rev": "9561691c9f450fad7c3526916e1c4f44be0d1192",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -2,7 +2,7 @@
   description = "The QUIC Copier (qcp) is an experimental high-performance remote file copy utility for long-distance internet connections.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
   };
 
   outputs =


### PR DESCRIPTION
Align with the current upstream stable and update to qcp current.