### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/crazyscot/qcp/compare/v0.6.0...v0.6.1)
+
+### ⛰️ Features
+
+- Add remote qcp binary override flag - ([2440370](https://github.com/crazyscot/qcp/commit/24403702eabae55e319cb0e02c421f95cc44a63a))
+
+### Deps
+
+- Prefer the finished 'paste' crate to the unvetted 'pastey' - ([58367c8](https://github.com/crazyscot/qcp/commit/58367c82460fb984627f6e8030f2539ad9f80750))
+
+
 ## [0.6.0](https://github.com/crazyscot/qcp/compare/v0.5.2...v0.6.0)
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "qcp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/qcp/Cargo.toml
+++ b/qcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qcp"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Ross Younger <qcp@crazyscot.com>"]
 categories = ["command-line-utilities"]
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `qcp`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1](https://github.com/crazyscot/qcp/compare/v0.6.0...v0.6.1)

### ⛰️ Features

- Add remote qcp binary override flag - ([2440370](https://github.com/crazyscot/qcp/commit/24403702eabae55e319cb0e02c421f95cc44a63a))

### Deps

- Prefer the finished 'paste' crate to the unvetted 'pastey' - ([58367c8](https://github.com/crazyscot/qcp/commit/58367c82460fb984627f6e8030f2539ad9f80750))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).