### PR TITLE
perf(io): speed up payload copy

### DIFF
--- a/qcp/src/session/get.rs
+++ b/qcp/src/session/get.rs
@@ -114,7 +114,7 @@ impl<S: SendingStream, R: ReceivingStream> SessionCommandImpl for Get<S, R> {
 
         let mut inbound = inbound.take(header.size.0);
         trace!("payload");
-        let _ = tokio::io::copy(&mut inbound, &mut file).await?;
+        let _ = crate::util::io::copy_large(&mut inbound, &mut file).await?;
         // Retrieve the stream from within the Take wrapper for further operations
         let mut inbound = inbound.into_inner();
 
@@ -168,7 +168,7 @@ impl<S: SendingStream, R: ReceivingStream> SessionCommandImpl for Get<S, R> {
         hdr.to_writer_async_framed(&mut self.stream.send).await?;
 
         trace!("sending file payload");
-        let result = tokio::io::copy(&mut file, &mut self.stream.send).await;
+        let result = crate::util::io::copy_large(&mut file, &mut self.stream.send).await;
         anyhow::ensure!(result.is_ok(), "copy ended prematurely");
         anyhow::ensure!(
             result.is_ok_and(|r| r == file_original_meta.len()),

--- a/qcp/src/session/put.rs
+++ b/qcp/src/session/put.rs
@@ -108,7 +108,7 @@ impl<S: SendingStream, R: ReceivingStream> SessionCommandImpl for Put<S, R> {
 
         // A server-side abort might happen part-way through a large transfer.
         trace!("send payload");
-        let result = tokio::io::copy(&mut file, &mut outbound).await;
+        let result = crate::util::io::copy_large(&mut file, &mut outbound).await;
 
         match result {
             Ok(sent) if sent == src_meta.len() => (),
@@ -269,7 +269,7 @@ async fn limited_copy(
     f: &mut TokioFile,
 ) -> Result<u64, std::io::Error> {
     let mut limited = recv.take(n);
-    tokio::io::copy(&mut limited, f).await
+    crate::util::io::copy_large(&mut limited, f).await
 }
 
 #[cfg(test)]

--- a/qcp/src/util/io.rs
+++ b/qcp/src/util/io.rs
@@ -3,7 +3,7 @@
 
 use crate::protocol::session::Status;
 use std::{io::ErrorKind, pin::Pin};
-use tokio::io::AsyncRead;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 pub(crate) fn status_from_error(e: &tokio::io::Error) -> (Status, Option<String>) {
     match e.kind() {
@@ -23,4 +23,171 @@ pub(crate) async fn read_available_non_blocking<R: AsyncRead + Unpin>(
         Pin::new(&mut reader).poll_read(cx, buffer)
     })
     .await
+}
+
+/// File transfer buffer size (bytes).
+///
+/// `tokio::io::copy` uses an internal 8KiB buffer, which can become CPU-bound at
+/// higher throughputs; qcp's typical use-case is large transfers, so we use a
+/// larger buffer.
+pub(crate) const DEFAULT_COPY_BUFFER_SIZE: usize = 1024 * 1024;
+
+pub(crate) async fn copy_large<R, W>(reader: &mut R, writer: &mut W) -> Result<u64, std::io::Error>
+where
+    R: AsyncRead + Unpin + ?Sized,
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    let mut reader = tokio::io::BufReader::with_capacity(DEFAULT_COPY_BUFFER_SIZE, reader);
+    tokio::io::copy_buf(&mut reader, writer).await
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod microbench {
+    use std::path::Path;
+    use std::time::Duration;
+
+    use anyhow::Context as _;
+    use human_repr::HumanCount as _;
+    use tokio::io::AsyncReadExt as _;
+
+    use super::{DEFAULT_COPY_BUFFER_SIZE, copy_large};
+
+    const DEFAULT_BYTES: u64 = 256 * 1024 * 1024;
+    const DEFAULT_WARMUP_BYTES: u64 = 64 * 1024 * 1024;
+    const DEFAULT_ITERS: usize = 5;
+
+    fn env_u64(name: &str) -> Option<u64> {
+        let value = std::env::var(name).ok()?;
+        value.parse().ok()
+    }
+
+    fn env_usize(name: &str) -> Option<usize> {
+        let value = std::env::var(name).ok()?;
+        value.parse().ok()
+    }
+
+    fn bytes_per_second(bytes: u64, duration: Duration) -> u64 {
+        let nanos = duration.as_nanos();
+        if nanos == 0 {
+            return u64::MAX;
+        }
+        let bytes_per_sec = u128::from(bytes).saturating_mul(1_000_000_000u128) / nanos;
+        u64::try_from(bytes_per_sec).unwrap_or(u64::MAX)
+    }
+
+    fn median(durations: &mut [Duration]) -> Duration {
+        durations.sort_unstable();
+        durations[durations.len() / 2]
+    }
+
+    async fn run_tokio_copy_file(path: &Path, bytes: u64) -> anyhow::Result<Duration> {
+        let file = tokio::fs::File::open(path)
+            .await
+            .with_context(|| format!("open {path:?}"))?;
+        let mut reader = file.take(bytes);
+        let mut writer = tokio::io::sink();
+        let start = std::time::Instant::now();
+        let copied = tokio::io::copy(&mut reader, &mut writer)
+            .await
+            .context("tokio::io::copy failed")?;
+        anyhow::ensure!(
+            copied == bytes,
+            "tokio::io::copy copied {copied}B, expected {bytes}B"
+        );
+        Ok(start.elapsed())
+    }
+
+    async fn run_copy_large_file(path: &Path, bytes: u64) -> anyhow::Result<Duration> {
+        let file = tokio::fs::File::open(path)
+            .await
+            .with_context(|| format!("open {path:?}"))?;
+        let mut reader = file.take(bytes);
+        let mut writer = tokio::io::sink();
+        let start = std::time::Instant::now();
+        let copied = copy_large(&mut reader, &mut writer)
+            .await
+            .context("copy_large failed")?;
+        anyhow::ensure!(
+            copied == bytes,
+            "copy_large copied {copied}B, expected {bytes}B"
+        );
+        Ok(start.elapsed())
+    }
+
+    /// Microbenchmark for the file payload copy path.
+    ///
+    /// Runs in release mode via:
+    /// `cargo test -p qcp --release microbench_copy_large_vs_tokio_copy -- --ignored --nocapture`
+    ///
+    /// Tune with env vars:
+    /// - `QCP_COPY_BENCH_BYTES` (default: 256MiB)
+    /// - `QCP_COPY_BENCH_WARMUP_BYTES` (default: 64MiB)
+    /// - `QCP_COPY_BENCH_ITERS` (default: 5)
+    #[tokio::test(flavor = "current_thread")]
+    #[ignore = "microbenchmark; run manually"]
+    async fn microbench_copy_large_vs_tokio_copy() -> anyhow::Result<()> {
+        let bytes = env_u64("QCP_COPY_BENCH_BYTES").unwrap_or(DEFAULT_BYTES);
+        let warmup_bytes = env_u64("QCP_COPY_BENCH_WARMUP_BYTES").unwrap_or(DEFAULT_WARMUP_BYTES);
+        let iters = env_usize("QCP_COPY_BENCH_ITERS").unwrap_or(DEFAULT_ITERS);
+        anyhow::ensure!(iters > 0, "QCP_COPY_BENCH_ITERS must be >0");
+
+        let tempdir = tempfile::tempdir().context("creating tempdir")?;
+        let file_path = tempdir.path().join("copybench.dat");
+        let file = tokio::fs::File::create(&file_path)
+            .await
+            .context("creating temp file")?;
+        file.set_len(bytes).await.context("setting file size")?;
+        drop(file);
+
+        eprintln!(
+            "qcp copy microbench: bytes {}, warmup {}, iters {}, copy_large buffer {}, source file {file_path:?}",
+            bytes.human_count_bytes(),
+            warmup_bytes.human_count_bytes(),
+            iters,
+            u64::try_from(DEFAULT_COPY_BUFFER_SIZE)
+                .unwrap_or(u64::MAX)
+                .human_count_bytes()
+        );
+
+        // Warm up caches/jit/etc.
+        let warmup_bytes = std::cmp::min(bytes, warmup_bytes);
+        let _ = run_tokio_copy_file(&file_path, warmup_bytes).await?;
+        let _ = run_copy_large_file(&file_path, warmup_bytes).await?;
+
+        let mut tokio_durations = Vec::with_capacity(iters);
+        let mut large_durations = Vec::with_capacity(iters);
+        for _ in 0..iters {
+            tokio_durations.push(run_tokio_copy_file(&file_path, bytes).await?);
+            large_durations.push(run_copy_large_file(&file_path, bytes).await?);
+        }
+
+        let tokio_median = median(&mut tokio_durations);
+        let large_median = median(&mut large_durations);
+
+        let tokio_bps = bytes_per_second(bytes, tokio_median);
+        let large_bps = bytes_per_second(bytes, large_median);
+
+        let improvement_pct = if tokio_bps == 0 {
+            None
+        } else {
+            let tokio_bps = i128::from(tokio_bps);
+            let large_bps = i128::from(large_bps);
+            Some((large_bps - tokio_bps) * 100 / tokio_bps)
+        };
+
+        eprintln!(
+            "tokio::io::copy      median {tokio_median:?}, {tokio_bps}/s",
+            tokio_bps = tokio_bps.human_count_bytes()
+        );
+        eprintln!(
+            "crate::io::copy_large median {large_median:?}, {large_bps}/s",
+            large_bps = large_bps.human_count_bytes()
+        );
+        if let Some(improvement_pct) = improvement_pct {
+            eprintln!("throughput change: {improvement_pct:+}%");
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR improves large-transfer throughput by replacing tokio::io::copy’s default 8KiB buffer with a larger buffered copy helper (copy_large, 1MiB) for the file payload path.

**What changed**
  - qcp/src/util/io.rs: add copy_large() and DEFAULT_COPY_BUFFER_SIZE (1MiB) using BufReader + tokio::io::copy_buf.
  - qcp/src/session/get.rs / qcp/src/session/put.rs: switch payload copies to crate::util::io::copy_large.

**Rationale**
  tokio::io::copy can become CPU-bound at high throughput due to its small internal buffer; qcp’s typical workload is large transfers where a bigger buffer is more efficient.

**Microbenchmark (included with this change)**
```
[host qcp]$ QCP_COPY_BENCH_BYTES=$((1024*1024*1024)) QCP_COPY_BENCH_ITERS=5 cargo test -p qcp --release microbench_copy_large_vs_tokio_copy -- --ignored --nocapture
...

    Finished `release` profile [optimized] target(s) in 1m 28s
     Running unittests src/lib.rs (target/release/deps/qcp-30e6ae2ec8631928)

running 1 test
qcp copy microbench: bytes 1.07GB, warmup 67.1MB, iters 5, copy_large buffer 1MB, source file "/tmp/.tmp2Sj1FF/copybench.dat"
tokio::io::copy      median 2.495384102s, 430.3MB/s
crate::io::copy_large median 191.06895ms, 5.62GB/s
throughput change: +1206%
test util::io::microbench::microbench_copy_large_vs_tokio_copy ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 291 filtered out; finished in 13.58s
...
```

**End-to-end transfer tests (two hosts)**

Old binaries (before this change):
```
host1 qcp]$ time target/release/qcp test_file host2: --rx 1000M
2025-12-12 10:09:04L  INFO Transferred 822.3MB in 5.07s; average 162MB/s; peak 237.3MB/s

real    0m5.364s
user    0m2.301s
sys     0m1.501s
[host1 qcp]$ time target/release/qcp /test_file host2: --rx 1000M
2025-12-12 10:09:17L  INFO Transferred 822.3MB in 6.64s; average 123.9MB/s; peak 342.6MB/s
2025-12-12 10:09:17L  WARN Congestion events detected: 7
2025-12-12 10:09:17L  WARN Lost packets: 2.6k/585.3k (0.45%, for 3.8MB)

real    0m6.954s
user    0m2.114s
sys     0m1.530s
[host1 qcp]$ time target/release/qcp test_file host2: --rx 1000M
2025-12-12 10:09:30L  INFO Transferred 822.3MB in 4.74s; average 173.5MB/s; peak 301.7MB/s
2025-12-12 10:09:30L  WARN Congestion events detected: 6
2025-12-12 10:09:30L  WARN Lost packets: 1.9k/601.9k (0.32%, for 2.8MB)

real    0m5.026s
user    0m2.129s
sys     0m1.403s
[host1 qcp]$ time target/release/qcp test_file host2: --rx 1000M
2025-12-12 10:09:49L  INFO Transferred 822.3MB in 5.04s; average 163.1MB/s; peak 241.7MB/s

real    0m5.329s
user    0m2.221s
sys     0m1.551s
```

New binaries:
```
# New binaries


[host1 qcp]$ time target/release/qcp test_file host2: --rx 1000M
2025-12-12 10:10:51L  INFO Transferred 822.3MB in 3.18s; average 258.5MB/s; peak 482.2MB/s
2025-12-12 10:10:51L  WARN Congestion events detected: 2
2025-12-12 10:10:51L  WARN Lost packets: 2.1k/581.7k (0.36%, for 3MB)

real    0m5.800s
user    0m1.008s
sys     0m0.765s
[host1 qcp]$ time target/release/qcp test_file host2: --rx 1000M
2025-12-12 10:10:57L  INFO Transferred 822.3MB in 3.09s; average 266.2MB/s; peak 507.9MB/s
2025-12-12 10:10:57L  WARN Congestion events detected: 7
2025-12-12 10:10:57L  WARN Lost packets: 3.5k/583k (0.59%, for 5MB)

real    0m3.375s
user    0m1.022s
sys     0m0.667s
[host1 qcp]$ time target/release/qcp test_file host2: --rx 1000M
2025-12-12 10:11:09L  INFO Transferred 822.3MB in 3.16s; average 260.4MB/s; peak 482.5MB/s
2025-12-12 10:11:09L  WARN Congestion events detected: 5
2025-12-12 10:11:09L  WARN Lost packets: 2.8k/582.4k (0.48%, for 4MB)

real    0m5.723s
user    0m1.030s
sys     0m0.763s
```

Both average and peak throughput were higher, and CPU usage (user + sys) was significantly lower.
In other tests between London and Sydney, the throughput increase was smaller (still an increase), but the reduction in CPU utilization remained.
