### PR TITLE
Multiple parallel transfer and skip transfer of existing files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "qcp"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,17 +138,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,7 +1426,6 @@ dependencies = [
  "anstyle",
  "anyhow",
  "assertables",
- "async-trait",
  "bytes",
  "cfg-if",
  "cfg_aliases",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "qcp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "qcp"
-version = "0.10.0"
+version = "0.8.3"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ enumscribe = "0.4.0"
 figment = "0.10.19"
 file-mode = "0.1.2"
 flate2 = "1.1.9"
-futures-util = { version = "0.3.32", default-features = false }
+futures-util = { version = "0.3.32", default-features = false, features = ["alloc"] }
 gethostname = "1.1.0"
 glob = "0.3.3"
 heck = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2024"
 anstyle = { version = "1.0.14", default-features = false }
 anyhow = "1.0.102"
 assertables = "9.9.0"
-async-trait = "0.1.89"
 bytes = "1.11.1"
 cargo_toml = "0.22.3"
 cfg-if = "1.0.4"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ high-performance remote file copy utility for long-distance internet connections
 
 ### News
 
+- **0.9** Added configurable parallel transfer degree (`-j`), end-to-end negotiation of parallelism, and faster recursive remote directory creation for deep trees
 - **0.8** Added support for multi-source transfers and directory recursion
 - **0.6** Improved TLS performance in some use cases (auto-selected cipher suite, RawPublicKey authentication)
 - **0.5**

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,7 +10,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qcp";
-  version = "0.8.3";
+  version = "0.9.0";
 
   # Tags required to fix the binary version
   GITHUB_REF_TYPE = "tag";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,7 +10,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qcp";
-  version = "0.9.0";
+  version = "0.8.3";
 
   # Tags required to fix the binary version
   GITHUB_REF_TYPE = "tag";

--- a/qcp-unsafe-tests/src/unix_umask.rs
+++ b/qcp-unsafe-tests/src/unix_umask.rs
@@ -15,6 +15,9 @@ async fn test_umask(initial: u16, set_umask: u16) {
     let dest = "dest";
     unsafe {
         // umask takes a u32 on Linux but a u16 on macos
+        #[cfg(target_os = "macos")]
+        libc::umask(set_umask);
+        #[cfg(not(target_os = "macos"))]
         libc::umask(set_umask.into());
     }
 

--- a/qcp/Cargo.toml
+++ b/qcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qcp"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["Ross Younger <qcp@crazyscot.com>"]
 categories = ["command-line-utilities"]
 edition.workspace = true

--- a/qcp/Cargo.toml
+++ b/qcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qcp"
-version = "0.10.0"
+version = "0.8.3"
 authors = ["Ross Younger <qcp@crazyscot.com>"]
 categories = ["command-line-utilities"]
 edition.workspace = true

--- a/qcp/Cargo.toml
+++ b/qcp/Cargo.toml
@@ -33,7 +33,6 @@ unstable-test-helpers = []
 [dependencies]
 anstyle = { workspace = true }
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 bytes = { workspace = true }
 cfg-if = { workspace = true }
 clap = { workspace = true }

--- a/qcp/Cargo.toml
+++ b/qcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qcp"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Ross Younger <qcp@crazyscot.com>"]
 categories = ["command-line-utilities"]
 edition.workspace = true

--- a/qcp/misc/generated/qcp.1
+++ b/qcp/misc/generated/qcp.1
@@ -14,7 +14,7 @@ qcp \- Secure remote file copy utility which uses the QUIC protocol over UDP
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SH SYNOPSIS
-\fBqcp\fR [\fB\-4 \fR] [\fB\-6 \fR] [\fB\-\-address\-family\fR] [\fB\-\-aes256\fR] [\fB\-\-color\fR] [\fB\-\-congestion\fR] [\fB\-\-initial\-congestion\-window\fR] [\fB\-\-initial\-mtu\fR] [\fB\-l\fR|\fB\-\-remote\-user\fR] [\fB\-\-log\-file\fR] [\fB\-\-max\-mtu\fR] [\fB\-\-min\-mtu\fR] [\fB\-p\fR|\fB\-\-preserve\fR] [\fB\-P\fR|\fB\-\-remote\-port\fR] [\fB\-\-packet\-threshold\fR] [\fB\-\-port\fR] [\fB\-\-profile\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-r\fR|\fB\-\-recurse\fR] [\fB\-\-remote\-qcp\-binary\fR] [\fB\-\-rx\fR] [\fB\-s\fR|\fB\-\-statistics\fR] [\fB\-S \fR] [\fB\-\-ssh\fR] [\fB\-\-ssh\-config\fR] [\fB\-\-ssh\-subsystem\fR] [\fB\-\-time\-format\fR] [\fB\-\-time\-threshold\fR] [\fB\-\-timeout\fR] [\fB\-\-tls\-auth\-type\fR] [\fB\-\-tx\fR] [\fB\-\-udp\-buffer\fR] [\fB\-\-rtt\fR] [\fB\-\-debug\fR] [\fB\-\-dry\-run\fR] [\fB\-\-io\-buffer\-size\fR] [\fB\-\-remote\-config\fR] [\fB\-\-remote\-debug\fR] [\fB\-\-config\-files\fR] [\fB\-\-help\-buffers\fR] [\fB\-\-list\-features\fR] [\fB\-\-show\-config\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fISOURCE|DESTINATION\fR] 
+\fBqcp\fR [\fB\-4 \fR] [\fB\-6 \fR] [\fB\-\-address\-family\fR] [\fB\-\-aes256\fR] [\fB\-\-color\fR] [\fB\-\-congestion\fR] [\fB\-\-initial\-congestion\-window\fR] [\fB\-\-initial\-mtu\fR] [\fB\-l\fR|\fB\-\-remote\-user\fR] [\fB\-\-log\-file\fR] [\fB\-\-max\-mtu\fR] [\fB\-\-min\-mtu\fR] [\fB\-p\fR|\fB\-\-preserve\fR] [\fB\-P\fR|\fB\-\-remote\-port\fR] [\fB\-\-packet\-threshold\fR] [\fB\-\-port\fR] [\fB\-\-profile\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-r\fR|\fB\-\-recurse\fR] [\fB\-\-remote\-qcp\-binary\fR] [\fB\-\-rx\fR] [\fB\-s\fR|\fB\-\-statistics\fR] [\fB\-S \fR] [\fB\-\-ssh\fR] [\fB\-\-ssh\-config\fR] [\fB\-\-ssh\-subsystem\fR] [\fB\-\-time\-format\fR] [\fB\-\-time\-threshold\fR] [\fB\-\-timeout\fR] [\fB\-\-tls\-auth\-type\fR] [\fB\-\-tx\fR] [\fB\-\-udp\-buffer\fR] [\fB\-j\fR|\fB\-\-parallel\fR] [\fB\-\-rtt\fR] [\fB\-\-debug\fR] [\fB\-\-dry\-run\fR] [\fB\-\-io\-buffer\-size\fR] [\fB\-\-remote\-config\fR] [\fB\-\-remote\-debug\fR] [\fB\-\-config\-files\fR] [\fB\-\-help\-buffers\fR] [\fB\-\-list\-features\fR] [\fB\-\-show\-config\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fISOURCE|DESTINATION\fR] 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SH DESCRIPTION
@@ -187,6 +187,15 @@ Specify as a number, or as an SI quantity (e.g. `10M`).
 
 This parameter is always interpreted as the _local_ bandwidth, whether operating in client or server mode. If not specified or 0, uses the value of `rx`.
 
+.TP
+\fB\-j\fR, \fB\-\-parallel\fR \fI<N>\fR
+Number of files to transfer concurrently. [default: 1]
+
+Increasing this helps saturate the channel when transferring many small files, because each file\*(Aqs transfer can overlap with others rather than waiting for each to complete serially.
+
+A value of 1 (the default) gives the same sequential behaviour as previous versions.
+
+**Note:** With `parallel > 1`, the QUIC receive buffer grows proportionally; very large values on memory\-constrained systems may need `udp\-buffer` tuning.
 .TP
 \fB\-\-rtt\fR \fI<ms>\fR
 The expected network Round Trip time to the target system, in milliseconds. [default: 300]

--- a/qcp/misc/generated/qcp.1
+++ b/qcp/misc/generated/qcp.1
@@ -14,7 +14,7 @@ qcp \- Secure remote file copy utility which uses the QUIC protocol over UDP
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SH SYNOPSIS
-\fBqcp\fR [\fB\-4 \fR] [\fB\-6 \fR] [\fB\-\-address\-family\fR] [\fB\-\-aes256\fR] [\fB\-\-color\fR] [\fB\-\-congestion\fR] [\fB\-\-initial\-congestion\-window\fR] [\fB\-\-initial\-mtu\fR] [\fB\-l\fR|\fB\-\-remote\-user\fR] [\fB\-\-log\-file\fR] [\fB\-\-max\-mtu\fR] [\fB\-\-min\-mtu\fR] [\fB\-p\fR|\fB\-\-preserve\fR] [\fB\-P\fR|\fB\-\-remote\-port\fR] [\fB\-\-packet\-threshold\fR] [\fB\-\-port\fR] [\fB\-\-profile\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-r\fR|\fB\-\-recurse\fR] [\fB\-\-remote\-qcp\-binary\fR] [\fB\-\-rx\fR] [\fB\-s\fR|\fB\-\-statistics\fR] [\fB\-S \fR] [\fB\-\-ssh\fR] [\fB\-\-ssh\-config\fR] [\fB\-\-ssh\-subsystem\fR] [\fB\-\-time\-format\fR] [\fB\-\-time\-threshold\fR] [\fB\-\-timeout\fR] [\fB\-\-tls\-auth\-type\fR] [\fB\-\-tx\fR] [\fB\-\-udp\-buffer\fR] [\fB\-j\fR|\fB\-\-parallel\fR] [\fB\-\-rtt\fR] [\fB\-\-debug\fR] [\fB\-\-dry\-run\fR] [\fB\-\-io\-buffer\-size\fR] [\fB\-\-remote\-config\fR] [\fB\-\-remote\-debug\fR] [\fB\-\-config\-files\fR] [\fB\-\-help\-buffers\fR] [\fB\-\-list\-features\fR] [\fB\-\-show\-config\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fISOURCE|DESTINATION\fR] 
+\fBqcp\fR [\fB\-4 \fR] [\fB\-6 \fR] [\fB\-\-address\-family\fR] [\fB\-\-aes256\fR] [\fB\-\-color\fR] [\fB\-\-congestion\fR] [\fB\-\-initial\-congestion\-window\fR] [\fB\-\-initial\-mtu\fR] [\fB\-l\fR|\fB\-\-remote\-user\fR] [\fB\-\-log\-file\fR] [\fB\-\-max\-mtu\fR] [\fB\-\-min\-mtu\fR] [\fB\-p\fR|\fB\-\-preserve\fR] [\fB\-P\fR|\fB\-\-remote\-port\fR] [\fB\-\-packet\-threshold\fR] [\fB\-\-port\fR] [\fB\-\-profile\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-r\fR|\fB\-\-recurse\fR] [\fB\-\-remote\-qcp\-binary\fR] [\fB\-\-rx\fR] [\fB\-s\fR|\fB\-\-statistics\fR] [\fB\-S \fR] [\fB\-\-skip\-existing\fR] [\fB\-\-ssh\fR] [\fB\-\-ssh\-config\fR] [\fB\-\-ssh\-subsystem\fR] [\fB\-\-time\-format\fR] [\fB\-\-time\-threshold\fR] [\fB\-\-timeout\fR] [\fB\-\-tls\-auth\-type\fR] [\fB\-\-tx\fR] [\fB\-\-udp\-buffer\fR] [\fB\-j\fR|\fB\-\-parallel\fR] [\fB\-\-rtt\fR] [\fB\-\-debug\fR] [\fB\-\-dry\-run\fR] [\fB\-\-io\-buffer\-size\fR] [\fB\-\-remote\-config\fR] [\fB\-\-remote\-debug\fR] [\fB\-\-config\-files\fR] [\fB\-\-help\-buffers\fR] [\fB\-\-list\-features\fR] [\fB\-\-show\-config\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fISOURCE|DESTINATION\fR] 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SH DESCRIPTION
@@ -100,6 +100,11 @@ Behaviour is intended to match scp.
 .TP
 \fB\-s\fR, \fB\-\-statistics\fR
 Show additional transfer statistics
+.TP
+\fB\-\-skip\-existing\fR
+Skips files where the destination already exists with the same size.
+
+When this option is set, if the destination file already exists and has the same size as the source file, the transfer of that file is skipped.
 .TP
 \fB\-\-time\-format\fR \fI<FORMAT>\fR
 The time format to use when printing messages to the console or to file [default: local]

--- a/qcp/misc/generated/qcp.html
+++ b/qcp/misc/generated/qcp.html
@@ -671,6 +671,29 @@
       the network.
     </p>
   </li>
+  <li>
+    <p>
+      <code>-j</code>, <code>--parallel &lt;N&gt;</code> — Number of files to
+      transfer concurrently. [default: 1]
+    </p>
+
+    <p>
+      Increasing this helps saturate the channel when transferring many small
+      files, because each file's transfer can overlap with others rather than
+      waiting for each to complete serially.
+    </p>
+
+    <p>
+      A value of 1 (the default) gives the same sequential behaviour as previous
+      versions.
+    </p>
+
+    <p>
+      <strong>Note:</strong> With <code>parallel &gt; 1</code>, the QUIC receive
+      buffer grows proportionally; very large values on memory-constrained
+      systems may need <code>udp-buffer</code> tuning.
+    </p>
+  </li>
 </ul>
 
 <hr />

--- a/qcp/misc/generated/qcp.html
+++ b/qcp/misc/generated/qcp.html
@@ -191,6 +191,17 @@
     <p>Behaviour is intended to match scp.</p>
   </li>
   <li>
+    <p>
+      <code>--skip-existing</code> — Skips files where the destination already
+      exists with the same size.
+    </p>
+
+    <p>
+      When this option is set, if the destination file already exists and has
+      the same size as the source file, the transfer of that file is skipped.
+    </p>
+  </li>
+  <li>
     <p><code>--log-file &lt;FILE&gt;</code> — Log to a file</p>
 
     <p>

--- a/qcp/misc/generated/qcp_config.5
+++ b/qcp/misc/generated/qcp_config.5
@@ -117,7 +117,7 @@ It is possible for included files to themselves include additional files; there 
 The following options from the CLI are supported in configuration files:
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-\fIrx\fR, \fItx\fR, \fIrtt\fR, \fIcongestion\fR, \fIinitial_congestion_window\fR, \fIport\fR, \fItimeout\fR, \fIudp_buffer\fR, \fIpacket_threshold\fR, \fItime_threshold\fR, \fIinitial_mtu\fR, \fImin_mtu\fR, \fImax_mtu\fR, \fIaddress_family\fR, \fIssh\fR, \fIremote_qcp_binary\fR, \fIssh_options\fR, \fIremote_port\fR, \fIremote_user\fR, \fItime_format\fR, \fIssh_config\fR, \fIssh_subsystem\fR, \fIcolor\fR, \fItls_auth_type\fR, \fIaes256\fR, \fIio_buffer_size\fR
+\fIrx\fR, \fItx\fR, \fIrtt\fR, \fIcongestion\fR, \fIinitial_congestion_window\fR, \fIport\fR, \fItimeout\fR, \fIudp_buffer\fR, \fIpacket_threshold\fR, \fItime_threshold\fR, \fIinitial_mtu\fR, \fImin_mtu\fR, \fImax_mtu\fR, \fIaddress_family\fR, \fIssh\fR, \fIremote_qcp_binary\fR, \fIssh_options\fR, \fIremote_port\fR, \fIremote_user\fR, \fItime_format\fR, \fIssh_config\fR, \fIssh_subsystem\fR, \fIcolor\fR, \fItls_auth_type\fR, \fIaes256\fR, \fIio_buffer_size\fR, \fIparallel\fR
 
 Refer to \fBqcp\fR(1) for details.
 

--- a/qcp/src/cli/args.rs
+++ b/qcp/src/cli/args.rs
@@ -286,6 +286,11 @@ impl CliArgs {
                 )?);
             }
         }
+        if self.client_params.skip_existing {
+            for job in &mut jobs {
+                job.skip_existing = true;
+            }
+        }
         Ok((success, jobs))
     }
 

--- a/qcp/src/client/job.rs
+++ b/qcp/src/client/job.rs
@@ -134,6 +134,8 @@ pub struct CopyJobSpec {
     /// If present, Unix-style mode bits to apply to the target.
     /// (This currently only applies to directories.)
     pub(crate) mode: Option<u32>,
+    /// If set, skip files on the destination that already have the same size as the source.
+    pub(crate) skip_existing: bool,
 }
 
 impl CopyJobSpec {
@@ -159,6 +161,7 @@ impl CopyJobSpec {
             preserve,
             directory,
             mode: None,
+            skip_existing: false,
         })
     }
 

--- a/qcp/src/client/main_loop.rs
+++ b/qcp/src/client/main_loop.rs
@@ -26,11 +26,14 @@ use crate::{
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use futures_util::stream::{FuturesUnordered, StreamExt as _};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use quinn::{Connection as QuinnConnection, Endpoint};
 use std::{
+    future::Future,
     net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6},
     path::MAIN_SEPARATOR,
+    pin::Pin,
 };
 use tokio::{
     self,
@@ -604,11 +607,11 @@ impl Client {
         &self,
         jobs_in: &[CopyJobSpec],
         mut open_stream: OpenStream,
-        mut run_job: JobRunner,
+        run_job: JobRunner,
     ) -> anyhow::Result<(bool, CommandStats)>
     where
         OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
-        JobRunner: AsyncFnMut(
+        JobRunner: AsyncFn(
             SendReceivePair<S, R>,
             CopyJobSpec,
             usize,
@@ -623,10 +626,10 @@ impl Client {
         let recurse: bool = self.args.client_params.recurse;
 
         if !destination_is_remote && recurse {
-            self.process_recursive_get(jobs_in, async move || open_stream().await, &mut run_job)
+            self.process_recursive_get(jobs_in, async move || open_stream().await, run_job)
                 .await
         } else {
-            self.process_file_transfers(jobs_in, async move || open_stream().await, &mut run_job)
+            self.process_file_transfers(jobs_in, async move || open_stream().await, run_job)
                 .await
         }
     }
@@ -636,11 +639,11 @@ impl Client {
         &self,
         jobs: &[CopyJobSpec],
         mut open_stream: OpenStream,
-        mut run_job: JobRunner,
+        run_job: JobRunner,
     ) -> anyhow::Result<(bool, CommandStats)>
     where
         OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
-        JobRunner: AsyncFnMut(
+        JobRunner: AsyncFn(
             SendReceivePair<S, R>,
             CopyJobSpec,
             usize,
@@ -655,79 +658,62 @@ impl Client {
         let destination_is_remote = jobs
             .first()
             .is_some_and(|j| j.destination.user_at_host.is_some());
-
-        // FILE TRANSFER PHASE
-        // Send/receive files and create directories.
-        // The list of job specs must be in the appropriate order i.e. create a directory before attempting to put any files into it.
-
-        let filename_width = longest_filename(jobs);
         let n_jobs = jobs.len();
-        let n_files = jobs.iter().filter(|j| !j.directory).count();
-        let mut files_done = 0;
-        for job in jobs {
-            if n_files > 1 {
-                self.spinner.set_message(format!(
-                    "Transferring data (file {} of {n_files})",
-                    files_done + 1,
-                ));
+        let parallel = self.negotiated_parallelism();
+
+        // DIRECTORY CREATION PHASE
+        // All directories must exist before parallel file transfers begin.
+        // For local destinations: create sequentially (cheap local syscalls).
+        // For remote destinations: if the server supports MKDIR_ALL (create_dir_all), send all
+        // mkdir requests in one parallel batch -- the server creates missing parents
+        // automatically so depth ordering is not required. Otherwise fall back to the depth-level
+        // batching strategy (sequential between depths, parallel within a depth).
+        if destination_is_remote {
+            let compat = self.negotiated.as_ref().unwrap().compat;
+            if compat.supports(Feature::MKDIR_ALL) {
+                create_remote_dirs_parallel(
+                    jobs,
+                    parallel,
+                    &mut open_stream,
+                    &run_job,
+                    &mut aggregate_stats,
+                    &mut overall_success,
+                )
+                .await?;
+            } else {
+                create_remote_dirs_by_depth(
+                    jobs,
+                    parallel,
+                    &mut open_stream,
+                    &run_job,
+                    &mut aggregate_stats,
+                    &mut overall_success,
+                )
+                .await?;
             }
-            if !destination_is_remote && job.directory {
-                // Local directory creation is trivial
-                debug!("Creating local directory {}", job.destination.filename);
-                let meta = tokio::fs::metadata(&job.destination.filename).await;
-                if let Ok(m) = meta {
-                    if m.is_file() {
-                        error!(
-                            "Cannot create local directory {}: a file already exists there",
-                            job.destination.filename
-                        );
-                        overall_success = false;
-                        break;
-                    }
-                    // directory already exists, that's fine
+        } else {
+            for job in jobs {
+                if !job.directory {
                     continue;
                 }
-                if let Err(e) = tokio::fs::create_dir_all(&job.destination.filename).await
-                    && e.kind() != std::io::ErrorKind::AlreadyExists
-                {
-                    error!(
-                        "Failed to create local directory {}: {e}",
-                        job.destination.filename
-                    );
+                if !handle_local_directory_creation(job).await {
                     overall_success = false;
                     break;
                 }
-                continue;
             }
-            debug!("Processing job {:?}", job);
-            let stream_pair = open_stream().await?;
-            let result = run_job(
-                stream_pair,
-                job.clone(),
-                filename_width,
-                TransferPhase::Transfer,
+        }
+
+        // FILE TRANSFER PHASE (parallel)
+        if overall_success {
+            self.transfer_files_phase(
+                jobs,
+                parallel,
+                &mut open_stream,
+                &run_job,
+                &mut aggregate_stats,
+                &mut overall_success,
             )
-            .await;
-            match result {
-                Ok(result) => {
-                    aggregate_stats.payload_bytes += result.stats.payload_bytes;
-                    aggregate_stats.peak_transfer_rate = aggregate_stats
-                        .peak_transfer_rate
-                        .max(result.stats.peak_transfer_rate);
-                }
-                Err(e) => {
-                    if let Some(src) = e.source() {
-                        // Some error conditions come with an anyhow Context.
-                        // We want to output one tidy line, so glue them together.
-                        error!("{e}: {src}");
-                    } else {
-                        error!("{e}");
-                    }
-                    overall_success = false;
-                    break;
-                }
-            }
-            files_done += 1;
+            .await?;
         }
 
         // POST-TRANSFER: Apply preserve logic (permission bits) to any directories created.
@@ -760,17 +746,18 @@ impl Client {
         Ok((overall_success, aggregate_stats))
     }
 
-    /// This function should generally log errors and return Ok(status, stats). Err(...) is reserved for fatal errors.
-    #[allow(clippy::too_many_lines)]
-    async fn process_recursive_get<S, R, OpenStream, JobRunner>(
+    async fn transfer_files_phase<S, R, OpenStream, JobRunner>(
         &self,
-        jobs_in: &[CopyJobSpec],
-        mut open_stream: OpenStream,
-        mut run_job: JobRunner,
-    ) -> anyhow::Result<(bool, CommandStats)>
+        jobs: &[CopyJobSpec],
+        parallel: usize,
+        open_stream: &mut OpenStream,
+        run_job: &JobRunner,
+        aggregate_stats: &mut CommandStats,
+        overall_success: &mut bool,
+    ) -> anyhow::Result<()>
     where
         OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
-        JobRunner: AsyncFnMut(
+        JobRunner: AsyncFn(
             SendReceivePair<S, R>,
             CopyJobSpec,
             usize,
@@ -779,6 +766,110 @@ impl Client {
         S: SendingStream + 'static,
         R: ReceivingStream + 'static,
     {
+        let filename_width = longest_filename(jobs);
+        let n_files = jobs.iter().filter(|j| !j.directory).count();
+        let mut in_flight: InFlightTransfers<'_> = FuturesUnordered::new();
+        let mut stop_launching = false;
+
+        for job in jobs {
+            if job.directory {
+                continue;
+            }
+            if stop_launching {
+                break;
+            }
+
+            // Drain finished tasks when we are at the concurrency limit.
+            while in_flight.len() >= parallel {
+                if let Some(result) = in_flight.next().await {
+                    collect_transfer_result(result, aggregate_stats, overall_success);
+                }
+                if !*overall_success {
+                    stop_launching = true;
+                    break;
+                }
+            }
+
+            if stop_launching {
+                break;
+            }
+
+            debug!("Processing job {:?}", job);
+            let stream_pair = open_stream().await?;
+
+            if n_files > 1 {
+                self.spinner.set_message(format!(
+                    "Transferring data ({} in flight)",
+                    in_flight.len() + 1,
+                ));
+            }
+
+            let job_clone = job.clone();
+            // Call run_job immediately (AsyncFn: &self, so concurrent calls are OK).
+            let transfer_fut = run_job(
+                stream_pair,
+                job_clone.clone(),
+                filename_width,
+                TransferPhase::Transfer,
+            );
+            in_flight.push(Box::pin(async move {
+                let result = transfer_fut.await;
+                (job_clone, result)
+            }));
+        }
+
+        // Drain remaining in-flight futures.
+        while !in_flight.is_empty() {
+            if let Some(result) = in_flight.next().await {
+                collect_transfer_result(result, aggregate_stats, overall_success);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// This function should generally log errors and return Ok(status, stats). Err(...) is reserved for fatal errors.
+    async fn process_recursive_get<S, R, OpenStream, JobRunner>(
+        &self,
+        jobs_in: &[CopyJobSpec],
+        mut open_stream: OpenStream,
+        run_job: JobRunner,
+    ) -> anyhow::Result<(bool, CommandStats)>
+    where
+        OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
+        JobRunner: AsyncFn(
+            SendReceivePair<S, R>,
+            CopyJobSpec,
+            usize,
+            TransferPhase,
+        ) -> Result<RequestResult>,
+        S: SendingStream + 'static,
+        R: ReceivingStream + 'static,
+    {
+        self.ensure_recursive_get_supported()?;
+        let single_source_mkdir_mode = determine_single_source_mkdir_mode(jobs_in).await?;
+        let new_jobs = self
+            .collect_recursive_jobs(
+                jobs_in,
+                single_source_mkdir_mode.is_none(),
+                &mut open_stream,
+                &run_job,
+            )
+            .await?;
+        apply_single_source_mkdir_mode(single_source_mkdir_mode, &new_jobs).await?;
+        self.process_file_transfers(&new_jobs, async move || open_stream().await, run_job)
+            .await
+    }
+
+    fn negotiated_parallelism(&self) -> usize {
+        usize::from(
+            self.negotiated
+                .as_ref()
+                .map_or(1, |n| n.config.parallel.max(1)),
+        )
+    }
+
+    fn ensure_recursive_get_supported(&self) -> anyhow::Result<()> {
         anyhow::ensure!(
             self.negotiated
                 .as_ref()
@@ -787,46 +878,27 @@ impl Client {
                 .supports(Feature::MKDIR_SETMETA_LS),
             "Operation not supported by remote"
         );
+        Ok(())
+    }
 
-        // If this is a recursive GET, check the local destination directory to fail fast.
-        // We try very hard to match scp behaviour here:
-        // - with one source:
-        //   - if the destination does not exist, and the source is a directory, create it; put the *contents* of remote folders into it (!)
-        //   - if the destination does not exist, and the source is a file, create it; put the *contents* of remote folders into it (!)
-        //   - if the destination exists and is a file, error; if it is a directory, copy the remote folders into it
-        // - with multiple sources:
-        //   - if the root (user entered) destination directory does not exist, error
-        //   - if the destination exists and is a file, error; if a directory, copy remote folders into it
-        //
-        // We signify the special single-source mode (marked '!' above) by setting single_source_mkdir_mode to Some(output_dir_name).
-        // We don't actually create the directory until we're sure we need to (i.e. we know from the remote that it is indeed a directory).
-
-        let original_dest_dir = &jobs_in
-            .first()
-            .expect("logic error: empty jobs list in recursive GET")
-            .destination
-            .filename;
-        let dest_meta = tokio::fs::metadata(original_dest_dir).await;
-        let single_source_mkdir_mode = if let Ok(meta) = dest_meta {
-            anyhow::ensure!(
-                !meta.is_file(),
-                "Local destination directory is a file: {original_dest_dir}"
-            );
-            // Directory exists; no special action needed.
-            None
-        } else {
-            // Directory does not exist
-            anyhow::ensure!(
-                jobs_in.len() == 1,
-                "Local destination directory {original_dest_dir} does not exist; with multiple source files/directories, the destination directory must exist",
-            );
-            // This is the special-case mode. The local destination directory doesn't exist; we will create it in a moment.
-            // (Not too soon, in case we bail before getting to the actual file transfer.)
-            Some(original_dest_dir.clone())
-        };
-
-        // PRE-TRANSFER:
-        // If this is a recursive GET, ask the remote to enumerate the files.
+    async fn collect_recursive_jobs<S, R, OpenStream, JobRunner>(
+        &self,
+        jobs_in: &[CopyJobSpec],
+        include_remote_dir_name: bool,
+        open_stream: &mut OpenStream,
+        run_job: &JobRunner,
+    ) -> anyhow::Result<Vec<CopyJobSpec>>
+    where
+        OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
+        JobRunner: AsyncFn(
+            SendReceivePair<S, R>,
+            CopyJobSpec,
+            usize,
+            TransferPhase,
+        ) -> Result<RequestResult>,
+        S: SendingStream + 'static,
+        R: ReceivingStream + 'static,
+    {
         self.spinner
             .set_message("Asking remote for list of files to transfer");
         let mut new_jobs = Vec::new();
@@ -841,74 +913,274 @@ impl Client {
                 );
             };
             for item in contents.entries {
-                let mut destfile = job.destination.filename.clone();
-                let leaf = item
-                    .name
-                    .strip_prefix(&job.source.filename)
-                    .unwrap_or(&item.name)
-                    .trim_start_matches(MAIN_SEPARATOR);
-                trace!("dest {destfile}");
-                if single_source_mkdir_mode.is_none() {
-                    // In normal mode, we need to add the remote directory name as well.
-                    let remote_dir_name = std::path::Path::new(&job.source.filename)
-                        .file_name()
-                        .and_then(|os_str| os_str.to_str())
-                        .unwrap_or_default();
-                    if !remote_dir_name.is_empty() {
-                        add_pathsep_if_needed(&mut destfile, true);
-                        destfile.push_str(remote_dir_name);
-                        trace! {"1smkdir: {destfile}"};
-                    }
-                }
-                if !leaf.is_empty() {
-                    add_pathsep_if_needed(&mut destfile, true);
-                    destfile.push_str(leaf);
-                }
-                trace!(
-                    "source path {name}; leaf {leaf:?}; final dest {destfile}",
-                    name = item.name
-                );
-                #[allow(clippy::cast_possible_truncation)]
-                new_jobs.push(CopyJobSpec {
-                    user_at_host: job.user_at_host.clone(),
-                    source: FileSpec {
-                        user_at_host: job.source.user_at_host.clone(),
-                        filename: item.name,
-                    },
-                    destination: FileSpec {
-                        user_at_host: job.destination.user_at_host.clone(),
-                        filename: destfile,
-                    },
-                    directory: item.directory,
-                    preserve: job.preserve,
-                    mode: item
-                        .attributes
-                        .find_tag(MetadataAttr::ModeBits)
-                        .map(|i| i.coerce_unsigned() as u32),
-                });
+                new_jobs.push(new_recursive_copy_job(job, item, include_remote_dir_name));
             }
         }
+        Ok(new_jobs)
+    }
+}
 
-        // Now, if required, handle single-source mkdir mode.
-        if let Some(dir_to_create) = single_source_mkdir_mode
-            && !new_jobs.is_empty()
-        {
-            if new_jobs[0].directory {
-                debug!("single source mode; item is a directory; creating it");
-                tokio::fs::create_dir_all(&dir_to_create)
-                    .await
-                    .context(format!(
-                        "while creating local destination directory {dir_to_create}",
-                    ))?;
-            } else {
-                debug!("single source mode; item is a file");
+type TransferResult = (CopyJobSpec, Result<RequestResult>);
+type InFlightTransfers<'a> = FuturesUnordered<Pin<Box<dyn Future<Output = TransferResult> + 'a>>>;
+
+fn collect_transfer_result(
+    result: TransferResult,
+    aggregate_stats: &mut CommandStats,
+    overall_success: &mut bool,
+) {
+    let (finished_job, result) = result;
+    match result {
+        Ok(r) => {
+            aggregate_stats.payload_bytes += r.stats.payload_bytes;
+            aggregate_stats.peak_transfer_rate = aggregate_stats
+                .peak_transfer_rate
+                .max(r.stats.peak_transfer_rate);
+        }
+        Err(ref e) => {
+            log_transfer_error(e, &finished_job);
+            *overall_success = false;
+        }
+    }
+}
+
+/// Creates all remote directories in a single parallel batch.
+///
+/// Relies on the server using `create_dir_all` (i.e. [`Feature::MKDIR_ALL`] is supported),
+/// so parent directories are created automatically and depth ordering is not required.
+async fn create_remote_dirs_parallel<S, R, OpenStream, JobRunner>(
+    jobs: &[CopyJobSpec],
+    parallel: usize,
+    open_stream: &mut OpenStream,
+    run_job: &JobRunner,
+    aggregate_stats: &mut CommandStats,
+    overall_success: &mut bool,
+) -> anyhow::Result<()>
+where
+    OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
+    JobRunner:
+        AsyncFn(SendReceivePair<S, R>, CopyJobSpec, usize, TransferPhase) -> Result<RequestResult>,
+    S: SendingStream + 'static,
+    R: ReceivingStream + 'static,
+{
+    let mut in_flight: InFlightTransfers<'_> = FuturesUnordered::new();
+    let mut stop_dirs = false;
+    for job in jobs {
+        if !job.directory {
+            continue;
+        }
+        if stop_dirs {
+            break;
+        }
+        while in_flight.len() >= parallel {
+            if let Some(result) = in_flight.next().await {
+                collect_transfer_result(result, aggregate_stats, overall_success);
+            }
+            if !*overall_success {
+                stop_dirs = true;
+                break;
             }
         }
+        if stop_dirs {
+            break;
+        }
+        debug!("Creating remote directory {:?}", job);
+        let stream_pair = open_stream().await?;
+        let j = job.clone();
+        let fut = run_job(stream_pair, j.clone(), 0, TransferPhase::Transfer);
+        in_flight.push(Box::pin(async move { (j, fut.await) }));
+    }
+    while let Some(result) = in_flight.next().await {
+        collect_transfer_result(result, aggregate_stats, overall_success);
+    }
+    Ok(())
+}
 
-        let new_jobs = new_jobs;
+/// Creates remote directories grouped by path depth.
+///
+/// All directories at a given depth are created in parallel (up to `parallel` concurrent
+/// streams), and the next depth level starts only after all directories at the current
+/// level are confirmed. This guarantees that parents always exist before children are
+/// attempted, while sibling directories at the same level are created concurrently.
+async fn create_remote_dirs_by_depth<S, R, OpenStream, JobRunner>(
+    jobs: &[CopyJobSpec],
+    parallel: usize,
+    open_stream: &mut OpenStream,
+    run_job: &JobRunner,
+    aggregate_stats: &mut CommandStats,
+    overall_success: &mut bool,
+) -> anyhow::Result<()>
+where
+    OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
+    JobRunner:
+        AsyncFn(SendReceivePair<S, R>, CopyJobSpec, usize, TransferPhase) -> Result<RequestResult>,
+    S: SendingStream + 'static,
+    R: ReceivingStream + 'static,
+{
+    use std::collections::BTreeMap;
+    let mut by_depth: BTreeMap<usize, Vec<&CopyJobSpec>> = BTreeMap::new();
+    for job in jobs {
+        if !job.directory {
+            continue;
+        }
+        let depth = std::path::Path::new(&job.destination.filename)
+            .components()
+            .count();
+        by_depth.entry(depth).or_default().push(job);
+    }
+    for batch in by_depth.values() {
+        if !*overall_success {
+            break;
+        }
+        let mut dir_flights: InFlightTransfers<'_> = FuturesUnordered::new();
+        let mut stop_dirs = false;
+        for job in batch {
+            if stop_dirs {
+                break;
+            }
+            while dir_flights.len() >= parallel {
+                if let Some(result) = dir_flights.next().await {
+                    collect_transfer_result(result, aggregate_stats, overall_success);
+                }
+                if !*overall_success {
+                    stop_dirs = true;
+                    break;
+                }
+            }
+            if stop_dirs {
+                break;
+            }
+            debug!("Creating remote directory {:?}", job);
+            let stream_pair = open_stream().await?;
+            let j = (*job).clone();
+            let fut = run_job(stream_pair, j.clone(), 0, TransferPhase::Transfer);
+            dir_flights.push(Box::pin(async move { (j, fut.await) }));
+        }
+        while let Some(result) = dir_flights.next().await {
+            collect_transfer_result(result, aggregate_stats, overall_success);
+        }
+    }
+    Ok(())
+}
 
-        self.process_file_transfers(&new_jobs, async move || open_stream().await, &mut run_job)
-            .await
+async fn handle_local_directory_creation(job: &CopyJobSpec) -> bool {
+    debug!("Creating local directory {}", job.destination.filename);
+    let meta = tokio::fs::metadata(&job.destination.filename).await;
+    if let Ok(m) = meta {
+        if m.is_file() {
+            error!(
+                "Cannot create local directory {}: a file already exists there",
+                job.destination.filename
+            );
+            return false;
+        }
+        // directory already exists, that's fine
+        return true;
+    }
+    if let Err(e) = tokio::fs::create_dir_all(&job.destination.filename).await
+        && e.kind() != std::io::ErrorKind::AlreadyExists
+    {
+        error!(
+            "Failed to create local directory {}: {e}",
+            job.destination.filename
+        );
+        return false;
+    }
+    true
+}
+
+async fn determine_single_source_mkdir_mode(
+    jobs_in: &[CopyJobSpec],
+) -> anyhow::Result<Option<String>> {
+    let original_dest_dir = &jobs_in
+        .first()
+        .expect("logic error: empty jobs list in recursive GET")
+        .destination
+        .filename;
+    let dest_meta = tokio::fs::metadata(original_dest_dir).await;
+    if let Ok(meta) = dest_meta {
+        anyhow::ensure!(
+            !meta.is_file(),
+            "Local destination directory is a file: {original_dest_dir}"
+        );
+        return Ok(None);
+    }
+
+    anyhow::ensure!(
+        jobs_in.len() == 1,
+        "Local destination directory {original_dest_dir} does not exist; with multiple source files/directories, the destination directory must exist",
+    );
+    Ok(Some(original_dest_dir.clone()))
+}
+
+async fn apply_single_source_mkdir_mode(
+    single_source_mkdir_mode: Option<String>,
+    new_jobs: &[CopyJobSpec],
+) -> anyhow::Result<()> {
+    if let Some(dir_to_create) = single_source_mkdir_mode
+        && !new_jobs.is_empty()
+    {
+        if new_jobs[0].directory {
+            debug!("single source mode; item is a directory; creating it");
+            tokio::fs::create_dir_all(&dir_to_create)
+                .await
+                .context(format!(
+                    "while creating local destination directory {dir_to_create}",
+                ))?;
+        } else {
+            debug!("single source mode; item is a file");
+        }
+    }
+    Ok(())
+}
+
+fn new_recursive_copy_job(
+    job: &CopyJobSpec,
+    item: crate::protocol::session::ListEntry,
+    include_remote_dir_name: bool,
+) -> CopyJobSpec {
+    let mut destfile = job.destination.filename.clone();
+    let leaf = item
+        .name
+        .strip_prefix(&job.source.filename)
+        .unwrap_or(&item.name)
+        .trim_start_matches(MAIN_SEPARATOR);
+    trace!("dest {destfile}");
+    if include_remote_dir_name {
+        let remote_dir_name = std::path::Path::new(&job.source.filename)
+            .file_name()
+            .and_then(|os_str| os_str.to_str())
+            .unwrap_or_default();
+        if !remote_dir_name.is_empty() {
+            add_pathsep_if_needed(&mut destfile, true);
+            destfile.push_str(remote_dir_name);
+            trace! {"1smkdir: {destfile}"};
+        }
+    }
+    if !leaf.is_empty() {
+        add_pathsep_if_needed(&mut destfile, true);
+        destfile.push_str(leaf);
+    }
+    trace!(
+        "source path {name}; leaf {leaf:?}; final dest {destfile}",
+        name = item.name
+    );
+    #[allow(clippy::cast_possible_truncation)]
+    CopyJobSpec {
+        user_at_host: job.user_at_host.clone(),
+        source: FileSpec {
+            user_at_host: job.source.user_at_host.clone(),
+            filename: item.name,
+        },
+        destination: FileSpec {
+            user_at_host: job.destination.user_at_host.clone(),
+            filename: destfile,
+        },
+        directory: item.directory,
+        preserve: job.preserve,
+        mode: item
+            .attributes
+            .find_tag(MetadataAttr::ModeBits)
+            .map(|i| i.coerce_unsigned() as u32),
     }
 }
 
@@ -920,13 +1192,23 @@ fn longest_filename(jobs: &[CopyJobSpec]) -> usize {
     result
 }
 
+fn log_transfer_error(e: &anyhow::Error, _job: &CopyJobSpec) {
+    if let Some(src) = e.source() {
+        // Some error conditions come with an anyhow Context.
+        // We want to output one tidy line, so glue them together.
+        error!("{e}: {src}");
+    } else {
+        error!("{e}");
+    }
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
     use indicatif::MultiProgress;
     use std::path::Path;
     use std::sync::{
-        Mutex,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     };
     use std::{
@@ -1572,5 +1854,94 @@ mod test {
         .unwrap();
         println!("Result: {r:?}");
         assert_eq!(r.stats.payload_bytes, 0);
+    }
+
+    /// Creates a `Client` with `parallel` set to `n` in the negotiated config.
+    fn make_uut_parallel(src: &str, dest: &str, n: u16) -> Client {
+        let mut client = make_uut(|_, _| (), src, dest, 4);
+        let mut cfg = Configuration::system_default().clone();
+        cfg.parallel = n;
+        client.negotiated = Some(Negotiated {
+            config: cfg,
+            compat: crate::protocol::control::Compatibility::Level(4),
+        });
+        client
+    }
+
+    /// Verifies that with `parallel = N`, all N files are eventually transferred.
+    #[tokio::test]
+    async fn process_file_transfers_runs_n_files_concurrently() {
+        use std::sync::atomic::AtomicUsize;
+        const N: u16 = 3;
+        const FILE_DATA: &[u8] = b"hi";
+
+        let uut = make_uut_parallel("127.0.0.1:src", "dst", N);
+
+        let jobs: Vec<CopyJobSpec> = (0..N)
+            .map(|i| {
+                CopyJobSpec::from_parts(
+                    &format!("127.0.0.1:file{i}"),
+                    &format!("out{i}"),
+                    false,
+                    false,
+                )
+                .unwrap()
+            })
+            .collect();
+
+        let conn_responses: Vec<Vec<u8>> = (0..N)
+            .map(|_| encode_get_success_response(FILE_DATA))
+            .collect();
+        let conn_responses = Arc::new(Mutex::new(conn_responses));
+
+        // Track the peak number of simultaneously open streams.
+        let concurrent_open = Arc::new(AtomicUsize::new(0));
+        let peak_concurrent = Arc::new(AtomicUsize::new(0));
+
+        let concurrent_open_c = concurrent_open.clone();
+        let peak_concurrent_c = peak_concurrent.clone();
+        let conn_responses_c = conn_responses.clone();
+
+        let (success, stats) = LitterTray::try_with_async(async |_| {
+            let (success, stats) = uut
+                .process_file_transfers(
+                    &jobs,
+                    || {
+                        let resp = conn_responses_c.lock().unwrap().remove(0);
+                        let open_c = concurrent_open_c.clone();
+                        let peak_c = peak_concurrent_c.clone();
+                        async move {
+                            let prev = open_c.fetch_add(1, Ordering::SeqCst);
+                            let _ = peak_c.fetch_max(prev + 1, Ordering::SeqCst);
+                            let (client_side, mut server_side) = new_test_plumbing();
+                            std::mem::drop(tokio::spawn(async move {
+                                let _ = server_side.send.write_all(&resp).await;
+                            }));
+                            Ok::<_, anyhow::Error>(client_side)
+                        }
+                    },
+                    |stream_pair, job, filename_width, pass| {
+                        let open_c = concurrent_open.clone();
+                        let fut = uut.run_request(stream_pair, job, filename_width, pass);
+                        async move {
+                            let r = fut.await;
+                            let _ = open_c.fetch_sub(1, Ordering::SeqCst);
+                            r
+                        }
+                    },
+                )
+                .await
+                .unwrap();
+            Ok((success, stats))
+        })
+        .await
+        .unwrap();
+
+        assert!(success);
+        // All N files should have been transferred.
+        assert_eq!(stats.payload_bytes, u64::from(N) * (FILE_DATA.len() as u64));
+        assert_eq!(conn_responses.lock().unwrap().len(), 0);
+        // At least one stream was opened.
+        assert!(peak_concurrent_c.load(Ordering::SeqCst) >= 1);
     }
 }

--- a/qcp/src/client/main_loop.rs
+++ b/qcp/src/client/main_loop.rs
@@ -25,7 +25,6 @@ use crate::{
 };
 
 use anyhow::{Context, Result};
-use async_trait::async_trait;
 use futures_util::stream::{FuturesUnordered, StreamExt as _};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use quinn::{Connection as QuinnConnection, Endpoint};
@@ -108,7 +107,6 @@ impl PrepResult {
 
 type ControlChannelType = ControlChannel<ChildStdin, ChildStdout>;
 
-#[async_trait]
 trait BiStreamOpener {
     type Send: SendingStream + 'static;
     type Recv: ReceivingStream + 'static;
@@ -117,7 +115,6 @@ trait BiStreamOpener {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))] // thin adapter around quinn
-#[async_trait]
 impl BiStreamOpener for QuinnConnection {
     type Send = quinn::SendStream;
     type Recv = quinn::RecvStream;
@@ -1226,7 +1223,6 @@ mod test {
     use tokio::io::AsyncWriteExt;
     use tokio::time::{Duration, timeout};
 
-    use async_trait::async_trait;
     use littertray::LitterTray;
 
     use super::{BiStreamOpener, RequestResult};
@@ -1736,7 +1732,6 @@ mod test {
         }
     }
 
-    #[async_trait]
     impl BiStreamOpener for FakeBiConnection {
         type Send = tokio::io::WriteHalf<tokio::io::SimplexStream>;
         type Recv = tokio::io::ReadHalf<tokio::io::SimplexStream>;

--- a/qcp/src/client/main_loop.rs
+++ b/qcp/src/client/main_loop.rs
@@ -254,6 +254,12 @@ impl Client {
                 self.args.client_params.statistics,
                 direction,
             );
+            if aggregate_stats.skipped_files > 0 {
+                info!(
+                    "{} file(s) skipped (destination already has same size)",
+                    aggregate_stats.skipped_files
+                );
+            }
         }
 
         if self.args.client_params.profile {
@@ -935,6 +941,7 @@ fn collect_transfer_result(
             aggregate_stats.peak_transfer_rate = aggregate_stats
                 .peak_transfer_rate
                 .max(r.stats.peak_transfer_rate);
+            aggregate_stats.skipped_files += r.stats.skipped_files;
         }
         Err(ref e) => {
             log_transfer_error(e, &finished_job);
@@ -1177,6 +1184,7 @@ fn new_recursive_copy_job(
         },
         directory: item.directory,
         preserve: job.preserve,
+        skip_existing: job.skip_existing,
         mode: item
             .attributes
             .find_tag(MetadataAttr::ModeBits)
@@ -1592,6 +1600,7 @@ mod test {
                 CommandStats {
                     payload_bytes: 10,
                     peak_transfer_rate: 100,
+                    ..Default::default()
                 },
                 None,
             ),
@@ -1599,6 +1608,7 @@ mod test {
                 CommandStats {
                     payload_bytes: 5,
                     peak_transfer_rate: 200,
+                    ..Default::default()
                 },
                 None,
             ),
@@ -1643,6 +1653,7 @@ mod test {
                 CommandStats {
                     payload_bytes: 10,
                     peak_transfer_rate: 100,
+                    ..Default::default()
                 },
                 None,
             )),
@@ -1652,6 +1663,7 @@ mod test {
                 CommandStats {
                     payload_bytes: 999,
                     peak_transfer_rate: 999,
+                    ..Default::default()
                 },
                 None,
             )),
@@ -1780,6 +1792,7 @@ mod test {
                 CommandStats {
                     payload_bytes: 10,
                     peak_transfer_rate: 100,
+                    ..Default::default()
                 },
                 None,
             ),

--- a/qcp/src/client/main_loop.rs
+++ b/qcp/src/client/main_loop.rs
@@ -637,6 +637,26 @@ impl Client {
         }
     }
 
+    fn is_parent_dir(parent: &str, child: &str) -> bool {
+        if parent == child {
+            return false;
+        }
+        if let Some(remainder) = child.strip_prefix(parent) {
+            if parent.ends_with(std::path::MAIN_SEPARATOR) {
+                return true;
+            }
+            return remainder.starts_with(std::path::MAIN_SEPARATOR);
+        }
+        false
+    }
+
+    fn is_empty_directory_job(job: &CopyJobSpec, jobs: &[CopyJobSpec]) -> bool {
+        job.directory
+            && !jobs
+                .iter()
+                .any(|other| Self::is_parent_dir(&job.source.filename, &other.source.filename))
+    }
+
     /// This function should generally log errors and return Ok(status, stats). Err(...) is reserved for fatal errors.
     async fn process_file_transfers<S, R, OpenStream, JobRunner>(
         &self,
@@ -657,178 +677,95 @@ impl Client {
     {
         let mut aggregate_stats = CommandStats::default();
         let mut overall_success = true;
-
+        let parallel = self.negotiated_parallelism();
         let destination_is_remote = jobs
             .first()
             .is_some_and(|j| j.destination.user_at_host.is_some());
         let n_jobs = jobs.len();
-        let parallel = self.negotiated_parallelism();
-
-        // DIRECTORY CREATION PHASE
-        // All directories must exist before parallel file transfers begin.
-        // For local destinations: create sequentially (cheap local syscalls).
-        // For remote destinations: if the server supports MKDIR_ALL (create_dir_all), send all
-        // mkdir requests in one parallel batch -- the server creates missing parents
-        // automatically so depth ordering is not required. Otherwise fall back to the depth-level
-        // batching strategy (sequential between depths, parallel within a depth).
-        if destination_is_remote {
-            let compat = self.negotiated.as_ref().unwrap().compat;
-            if compat.supports(Feature::MKDIR_ALL) {
-                create_remote_dirs_parallel(
-                    jobs,
-                    parallel,
-                    &mut open_stream,
-                    &run_job,
-                    &mut aggregate_stats,
-                    &mut overall_success,
-                )
-                .await?;
-            } else {
-                create_remote_dirs_by_depth(
-                    jobs,
-                    parallel,
-                    &mut open_stream,
-                    &run_job,
-                    &mut aggregate_stats,
-                    &mut overall_success,
-                )
-                .await?;
-            }
-        } else {
-            for job in jobs {
-                if !job.directory {
-                    continue;
-                }
-                if !handle_local_directory_creation(job).await {
-                    overall_success = false;
-                    break;
-                }
-            }
-        }
-
-        // FILE TRANSFER PHASE (parallel)
-        if overall_success {
-            self.transfer_files_phase(
-                jobs,
-                parallel,
-                &mut open_stream,
-                &run_job,
-                &mut aggregate_stats,
-                &mut overall_success,
-            )
-            .await?;
-        }
-
-        // POST-TRANSFER: Apply preserve logic (permission bits) to any directories created.
-        // We do this in _reverse order_ in case the changed permissions prevent us from being able to traverse a directory we recently created.
-        if n_jobs > 1 {
-            let mut message_set = false;
-            for job in jobs.iter().rev() {
-                if job.directory && job.preserve {
-                    let stream_pair = open_stream().await?;
-                    if !message_set {
-                        self.spinner
-                            .set_message("Finishing up directory permissions");
-                        message_set = true;
-                    }
-                    let result = run_job(stream_pair, job.clone(), 0, TransferPhase::Post).await;
-                    if let Err(e) = result {
-                        if let Some(src) = e.source() {
-                            // Some error conditions come with an anyhow Context.
-                            // We want to output one tidy line, so glue them together.
-                            error!("{e}: {src}");
-                        } else {
-                            error!("{e}");
-                        }
-                        overall_success = false;
-                    }
-                }
-            }
-        }
-
-        Ok((overall_success, aggregate_stats))
-    }
-
-    async fn transfer_files_phase<S, R, OpenStream, JobRunner>(
-        &self,
-        jobs: &[CopyJobSpec],
-        parallel: usize,
-        open_stream: &mut OpenStream,
-        run_job: &JobRunner,
-        aggregate_stats: &mut CommandStats,
-        overall_success: &mut bool,
-    ) -> anyhow::Result<()>
-    where
-        OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
-        JobRunner: AsyncFn(
-            SendReceivePair<S, R>,
-            CopyJobSpec,
-            usize,
-            TransferPhase,
-        ) -> Result<RequestResult>,
-        S: SendingStream + 'static,
-        R: ReceivingStream + 'static,
-    {
         let filename_width = longest_filename(jobs);
         let n_files = jobs.iter().filter(|j| !j.directory).count();
+
         let mut in_flight: InFlightTransfers<'_> = FuturesUnordered::new();
         let mut stop_launching = false;
 
         for job in jobs {
-            if job.directory {
-                continue;
-            }
             if stop_launching {
                 break;
             }
 
-            // Drain finished tasks when we are at the concurrency limit.
-            while in_flight.len() >= parallel {
-                if let Some(result) = in_flight.next().await {
-                    collect_transfer_result(result, aggregate_stats, overall_success);
+            if job.directory {
+                if Self::is_empty_directory_job(job, jobs) {
+                    if destination_is_remote {
+                        stop_launching = !drain_in_flight(
+                            &mut in_flight,
+                            parallel,
+                            &mut aggregate_stats,
+                            &mut overall_success,
+                        )
+                        .await;
+                        if stop_launching {
+                            break;
+                        }
+                        debug!("Creating remote empty directory {:?}", job);
+                        enqueue_transfer_job(
+                            job,
+                            filename_width,
+                            TransferPhase::Transfer,
+                            &mut in_flight,
+                            &mut open_stream,
+                            &run_job,
+                        )
+                        .await?;
+                    } else if !create_local_empty_directory(job).await {
+                        overall_success = false;
+                        break;
+                    }
                 }
-                if !*overall_success {
-                    stop_launching = true;
-                    break;
-                }
+                continue;
             }
 
+            stop_launching = !drain_in_flight(
+                &mut in_flight,
+                parallel,
+                &mut aggregate_stats,
+                &mut overall_success,
+            )
+            .await;
             if stop_launching {
                 break;
             }
 
             debug!("Processing job {:?}", job);
-            let stream_pair = open_stream().await?;
-
             if n_files > 1 {
                 self.spinner.set_message(format!(
                     "Transferring data ({} in flight)",
-                    in_flight.len() + 1,
+                    in_flight.len() + 1
                 ));
             }
-
-            let job_clone = job.clone();
-            // Call run_job immediately (AsyncFn: &self, so concurrent calls are OK).
-            let transfer_fut = run_job(
-                stream_pair,
-                job_clone.clone(),
+            enqueue_transfer_job(
+                job,
                 filename_width,
                 TransferPhase::Transfer,
-            );
-            in_flight.push(Box::pin(async move {
-                let result = transfer_fut.await;
-                (job_clone, result)
-            }));
+                &mut in_flight,
+                &mut open_stream,
+                &run_job,
+            )
+            .await?;
         }
 
-        // Drain remaining in-flight futures.
-        while !in_flight.is_empty() {
-            if let Some(result) = in_flight.next().await {
-                collect_transfer_result(result, aggregate_stats, overall_success);
-            }
-        }
+        drain_remaining_in_flight(&mut in_flight, &mut aggregate_stats, &mut overall_success).await;
 
-        Ok(())
+        apply_directory_metadata(
+            self,
+            jobs,
+            n_jobs,
+            &mut open_stream,
+            &run_job,
+            &mut overall_success,
+        )
+        .await?;
+
+        Ok((overall_success, aggregate_stats))
     }
 
     /// This function should generally log errors and return Ok(status, stats). Err(...) is reserved for fatal errors.
@@ -926,6 +863,117 @@ impl Client {
 type TransferResult = (CopyJobSpec, Result<RequestResult>);
 type InFlightTransfers<'a> = FuturesUnordered<Pin<Box<dyn Future<Output = TransferResult> + 'a>>>;
 
+async fn drain_in_flight(
+    in_flight: &mut InFlightTransfers<'_>,
+    parallel: usize,
+    aggregate_stats: &mut CommandStats,
+    overall_success: &mut bool,
+) -> bool {
+    while in_flight.len() >= parallel {
+        if let Some(result) = in_flight.next().await {
+            collect_transfer_result(result, aggregate_stats, overall_success);
+        }
+        if !*overall_success {
+            return false;
+        }
+    }
+    true
+}
+
+async fn enqueue_transfer_job<'a, S, R, OpenStream, JobRunner>(
+    job: &CopyJobSpec,
+    filename_width: usize,
+    phase: TransferPhase,
+    in_flight: &mut InFlightTransfers<'a>,
+    open_stream: &mut OpenStream,
+    run_job: &'a JobRunner,
+) -> anyhow::Result<()>
+where
+    OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
+    JobRunner:
+        AsyncFn(SendReceivePair<S, R>, CopyJobSpec, usize, TransferPhase) -> Result<RequestResult>,
+    S: SendingStream + 'static,
+    R: ReceivingStream + 'static,
+{
+    let stream_pair = open_stream().await?;
+    let job_clone = job.clone();
+    let transfer_fut = run_job(stream_pair, job_clone.clone(), filename_width, phase);
+    in_flight.push(Box::pin(async move { (job_clone, transfer_fut.await) }));
+    Ok(())
+}
+
+async fn create_local_empty_directory(job: &CopyJobSpec) -> bool {
+    debug!(
+        "Creating local empty directory {}",
+        job.destination.filename
+    );
+    if let Err(e) = tokio::fs::create_dir_all(&job.destination.filename).await
+        && e.kind() != std::io::ErrorKind::AlreadyExists
+    {
+        error!(
+            "Failed to create local directory {}: {e}",
+            job.destination.filename
+        );
+        return false;
+    }
+    true
+}
+
+async fn drain_remaining_in_flight(
+    in_flight: &mut InFlightTransfers<'_>,
+    aggregate_stats: &mut CommandStats,
+    overall_success: &mut bool,
+) {
+    while !in_flight.is_empty() {
+        if let Some(result) = in_flight.next().await {
+            collect_transfer_result(result, aggregate_stats, overall_success);
+        }
+    }
+}
+
+async fn apply_directory_metadata<S, R, OpenStream, JobRunner>(
+    client: &Client,
+    jobs: &[CopyJobSpec],
+    n_jobs: usize,
+    open_stream: &mut OpenStream,
+    run_job: &JobRunner,
+    overall_success: &mut bool,
+) -> anyhow::Result<()>
+where
+    OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
+    JobRunner:
+        AsyncFn(SendReceivePair<S, R>, CopyJobSpec, usize, TransferPhase) -> Result<RequestResult>,
+    S: SendingStream + 'static,
+    R: ReceivingStream + 'static,
+{
+    if n_jobs <= 1 {
+        return Ok(());
+    }
+
+    let mut message_set = false;
+    for job in jobs.iter().rev() {
+        if job.directory && job.preserve {
+            let stream_pair = open_stream().await?;
+            if !message_set {
+                client
+                    .spinner
+                    .set_message("Finishing up directory permissions");
+                message_set = true;
+            }
+            let result = run_job(stream_pair, job.clone(), 0, TransferPhase::Post).await;
+            if let Err(e) = result {
+                if let Some(src) = e.source() {
+                    error!("{e}: {src}");
+                } else {
+                    error!("{e}");
+                }
+                *overall_success = false;
+            }
+        }
+    }
+    Ok(())
+}
+
 fn collect_transfer_result(
     result: TransferResult,
     aggregate_stats: &mut CommandStats,
@@ -945,151 +993,6 @@ fn collect_transfer_result(
             *overall_success = false;
         }
     }
-}
-
-/// Creates all remote directories in a single parallel batch.
-///
-/// Relies on the server using `create_dir_all` (i.e. [`Feature::MKDIR_ALL`] is supported),
-/// so parent directories are created automatically and depth ordering is not required.
-async fn create_remote_dirs_parallel<S, R, OpenStream, JobRunner>(
-    jobs: &[CopyJobSpec],
-    parallel: usize,
-    open_stream: &mut OpenStream,
-    run_job: &JobRunner,
-    aggregate_stats: &mut CommandStats,
-    overall_success: &mut bool,
-) -> anyhow::Result<()>
-where
-    OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
-    JobRunner:
-        AsyncFn(SendReceivePair<S, R>, CopyJobSpec, usize, TransferPhase) -> Result<RequestResult>,
-    S: SendingStream + 'static,
-    R: ReceivingStream + 'static,
-{
-    let mut in_flight: InFlightTransfers<'_> = FuturesUnordered::new();
-    let mut stop_dirs = false;
-    for job in jobs {
-        if !job.directory {
-            continue;
-        }
-        if stop_dirs {
-            break;
-        }
-        while in_flight.len() >= parallel {
-            if let Some(result) = in_flight.next().await {
-                collect_transfer_result(result, aggregate_stats, overall_success);
-            }
-            if !*overall_success {
-                stop_dirs = true;
-                break;
-            }
-        }
-        if stop_dirs {
-            break;
-        }
-        debug!("Creating remote directory {:?}", job);
-        let stream_pair = open_stream().await?;
-        let j = job.clone();
-        let fut = run_job(stream_pair, j.clone(), 0, TransferPhase::Transfer);
-        in_flight.push(Box::pin(async move { (j, fut.await) }));
-    }
-    while let Some(result) = in_flight.next().await {
-        collect_transfer_result(result, aggregate_stats, overall_success);
-    }
-    Ok(())
-}
-
-/// Creates remote directories grouped by path depth.
-///
-/// All directories at a given depth are created in parallel (up to `parallel` concurrent
-/// streams), and the next depth level starts only after all directories at the current
-/// level are confirmed. This guarantees that parents always exist before children are
-/// attempted, while sibling directories at the same level are created concurrently.
-async fn create_remote_dirs_by_depth<S, R, OpenStream, JobRunner>(
-    jobs: &[CopyJobSpec],
-    parallel: usize,
-    open_stream: &mut OpenStream,
-    run_job: &JobRunner,
-    aggregate_stats: &mut CommandStats,
-    overall_success: &mut bool,
-) -> anyhow::Result<()>
-where
-    OpenStream: AsyncFnMut() -> anyhow::Result<SendReceivePair<S, R>>,
-    JobRunner:
-        AsyncFn(SendReceivePair<S, R>, CopyJobSpec, usize, TransferPhase) -> Result<RequestResult>,
-    S: SendingStream + 'static,
-    R: ReceivingStream + 'static,
-{
-    use std::collections::BTreeMap;
-    let mut by_depth: BTreeMap<usize, Vec<&CopyJobSpec>> = BTreeMap::new();
-    for job in jobs {
-        if !job.directory {
-            continue;
-        }
-        let depth = std::path::Path::new(&job.destination.filename)
-            .components()
-            .count();
-        by_depth.entry(depth).or_default().push(job);
-    }
-    for batch in by_depth.values() {
-        if !*overall_success {
-            break;
-        }
-        let mut dir_flights: InFlightTransfers<'_> = FuturesUnordered::new();
-        let mut stop_dirs = false;
-        for job in batch {
-            if stop_dirs {
-                break;
-            }
-            while dir_flights.len() >= parallel {
-                if let Some(result) = dir_flights.next().await {
-                    collect_transfer_result(result, aggregate_stats, overall_success);
-                }
-                if !*overall_success {
-                    stop_dirs = true;
-                    break;
-                }
-            }
-            if stop_dirs {
-                break;
-            }
-            debug!("Creating remote directory {:?}", job);
-            let stream_pair = open_stream().await?;
-            let j = (*job).clone();
-            let fut = run_job(stream_pair, j.clone(), 0, TransferPhase::Transfer);
-            dir_flights.push(Box::pin(async move { (j, fut.await) }));
-        }
-        while let Some(result) = dir_flights.next().await {
-            collect_transfer_result(result, aggregate_stats, overall_success);
-        }
-    }
-    Ok(())
-}
-
-async fn handle_local_directory_creation(job: &CopyJobSpec) -> bool {
-    debug!("Creating local directory {}", job.destination.filename);
-    let meta = tokio::fs::metadata(&job.destination.filename).await;
-    if let Ok(m) = meta {
-        if m.is_file() {
-            error!(
-                "Cannot create local directory {}: a file already exists there",
-                job.destination.filename
-            );
-            return false;
-        }
-        // directory already exists, that's fine
-        return true;
-    }
-    if let Err(e) = tokio::fs::create_dir_all(&job.destination.filename).await
-        && e.kind() != std::io::ErrorKind::AlreadyExists
-    {
-        error!(
-            "Failed to create local directory {}: {e}",
-            job.destination.filename
-        );
-        return false;
-    }
-    true
 }
 
 async fn determine_single_source_mkdir_mode(

--- a/qcp/src/client/main_loop.rs
+++ b/qcp/src/client/main_loop.rs
@@ -1644,8 +1644,11 @@ mod test {
 
         fn open_bi_stream(
             &self,
-        ) -> impl Future<Output = anyhow::Result<crate::protocol::common::SendReceivePair<Self::Send, Self::Recv>>>
-        {
+        ) -> impl Future<
+            Output = anyhow::Result<
+                crate::protocol::common::SendReceivePair<Self::Send, Self::Recv>,
+            >,
+        > {
             let (client_side, mut server_side) = new_test_plumbing();
             let _ = self.open_calls.fetch_add(1, Ordering::SeqCst);
             let response = self.responses.lock().unwrap().remove(0);

--- a/qcp/src/client/main_loop.rs
+++ b/qcp/src/client/main_loop.rs
@@ -1642,9 +1642,9 @@ mod test {
         type Send = tokio::io::WriteHalf<tokio::io::SimplexStream>;
         type Recv = tokio::io::ReadHalf<tokio::io::SimplexStream>;
 
-        async fn open_bi_stream(
+        fn open_bi_stream(
             &self,
-        ) -> anyhow::Result<crate::protocol::common::SendReceivePair<Self::Send, Self::Recv>>
+        ) -> impl Future<Output = anyhow::Result<crate::protocol::common::SendReceivePair<Self::Send, Self::Recv>>>
         {
             let (client_side, mut server_side) = new_test_plumbing();
             let _ = self.open_calls.fetch_add(1, Ordering::SeqCst);
@@ -1652,7 +1652,7 @@ mod test {
             std::mem::drop(tokio::spawn(async move {
                 let _ = server_side.send.write_all(&response).await;
             }));
-            Ok(client_side)
+            std::future::ready(Ok(client_side))
         }
     }
 

--- a/qcp/src/client/main_loop.rs
+++ b/qcp/src/client/main_loop.rs
@@ -1310,7 +1310,10 @@ mod test {
     }
 
     #[cfg(unix)] // this test depends on create_fake, which is not implemented on Windows
-    #[cfg_attr(target_os = "macos", ignore)]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "this test depends on create_fake, which is not implemented on macOS"
+    )]
     #[tokio::test]
     async fn endpoint_create_close() {
         use crate::client::main_loop::QcpConnection;
@@ -1350,7 +1353,7 @@ mod test {
         eprintln!("Closedown report: {report:?}");
     }
 
-    #[cfg_attr(target_os = "macos", ignore)]
+    #[cfg_attr(target_os = "macos", ignore = "fails under CI on macOS")]
     #[cfg_attr(target_os = "windows", ignore = "fails under Wine in CI")]
     #[tokio::test]
     async fn quinn_connection_open_bi_stream_adapter_works() {

--- a/qcp/src/client/options.rs
+++ b/qcp/src/client/options.rs
@@ -88,6 +88,13 @@ pub struct Parameters {
         )
     )]
     pub recurse: bool,
+
+    /// Skips files where the destination already exists with the same size.
+    ///
+    /// When this option is set, if the destination file already exists and has the
+    /// same size as the source file, the transfer of that file is skipped.
+    #[arg(long, display_order(0))]
+    pub skip_existing: bool,
 }
 
 #[cfg(test)]

--- a/qcp/src/config/structure.rs
+++ b/qcp/src/config/structure.rs
@@ -547,6 +547,24 @@ CLI options take precedence over the configuration file, which takes precedence 
         serialize_with = "EQHelper::to_string_figment"
     )]
     pub io_buffer_size: u64,
+
+    /// Number of files to transfer concurrently. [default: 1]
+    ///
+    /// Increasing this helps saturate the channel when transferring many small files,
+    /// because each file's transfer can overlap with others rather than waiting for each to complete serially.
+    ///
+    /// A value of 1 (the default) gives the same sequential behaviour as previous versions.
+    ///
+    /// **Note:** With `parallel > 1`, the QUIC receive buffer grows proportionally;
+    /// very large values on memory-constrained systems may need `udp-buffer` tuning.
+    #[arg(
+        short = 'j',
+        long,
+        value_name = "N",
+        help_heading("Tuning"),
+        display_order(1),
+    )]
+    pub parallel: u16,
 }
 
 static SYSTEM_DEFAULT_CONFIG: LazyLock<Configuration> = LazyLock::new(|| Configuration {
@@ -582,6 +600,9 @@ static SYSTEM_DEFAULT_CONFIG: LazyLock<Configuration> = LazyLock::new(|| Configu
     // Other
     tls_auth_type: CredentialsType::Any,
     aes256: false,
+
+    // Transfer concurrency
+    parallel: 1,
 });
 
 impl Configuration {

--- a/qcp/src/config/structure.rs
+++ b/qcp/src/config/structure.rs
@@ -562,7 +562,7 @@ CLI options take precedence over the configuration file, which takes precedence 
         long,
         value_name = "N",
         help_heading("Tuning"),
-        display_order(1),
+        display_order(1)
     )]
     pub parallel: u16,
 }

--- a/qcp/src/control/channel.rs
+++ b/qcp/src/control/channel.rs
@@ -445,14 +445,15 @@ impl<S: SendingStream + 'static, R: ReceivingStream + 'static> ControlChannelSer
             );
         }
 
-        let config = match combine_bandwidth_configurations(manager, &message2, self.selected_compat) {
-            Ok(cfg) => cfg,
-            Err(e) => {
-                self.send_error(ServerFailure::NegotiationFailed(format!("{e}")))
-                    .await?;
-                anyhow::bail!("Config negotiation failed: {e}");
-            }
-        };
+        let config =
+            match combine_bandwidth_configurations(manager, &message2, self.selected_compat) {
+                Ok(cfg) => cfg,
+                Err(e) => {
+                    self.send_error(ServerFailure::NegotiationFailed(format!("{e}")))
+                        .await?;
+                    anyhow::bail!("Config negotiation failed: {e}");
+                }
+            };
 
         if show_config {
             info!(

--- a/qcp/src/control/channel.rs
+++ b/qcp/src/control/channel.rs
@@ -445,7 +445,7 @@ impl<S: SendingStream + 'static, R: ReceivingStream + 'static> ControlChannelSer
             );
         }
 
-        let config = match combine_bandwidth_configurations(manager, &message2) {
+        let config = match combine_bandwidth_configurations(manager, &message2, self.selected_compat) {
             Ok(cfg) => cfg,
             Err(e) => {
                 self.send_error(ServerFailure::NegotiationFailed(format!("{e}")))

--- a/qcp/src/control/channel.rs
+++ b/qcp/src/control/channel.rs
@@ -7,7 +7,6 @@
 use std::time::Duration;
 
 use anyhow::{Context as _, Result};
-use async_trait::async_trait;
 use quinn::{ConnectionStats, Endpoint};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _, Stdin, Stdout};
 use tokio::time::timeout;
@@ -33,7 +32,6 @@ use mockall::{automock, predicate::*};
 
 /// Control channel abstraction
 #[cfg_attr(test, automock)]
-#[async_trait]
 pub(crate) trait ControlChannelServerInterface<
     S: SendingStream + 'static,
     R: ReceivingStream + 'static,
@@ -385,7 +383,6 @@ impl<S: SendingStream, R: ReceivingStream> ControlChannel<S, R> {
     }
 }
 
-#[async_trait]
 impl<S: SendingStream + 'static, R: ReceivingStream + 'static> ControlChannelServerInterface<S, R>
     for ControlChannel<S, R>
 {

--- a/qcp/src/control/channel.rs
+++ b/qcp/src/control/channel.rs
@@ -31,6 +31,11 @@ use crate::util::{Credentials, TimeFormat, TracingSetupFn};
 use mockall::{automock, predicate::*};
 
 /// Control channel abstraction
+#[allow(unknown_lints, reason = "clippy::unused_async_trait_impl is new")]
+#[allow(
+    clippy::unused_async_trait_impl,
+    reason = "failure created by external package"
+)]
 #[cfg_attr(test, automock)]
 pub(crate) trait ControlChannelServerInterface<
     S: SendingStream + 'static,

--- a/qcp/src/protocol/compat.rs
+++ b/qcp/src/protocol/compat.rs
@@ -61,6 +61,7 @@ def_enum!(
         GET2_PUT2 => Compatibility::Level(2) => "Get2 and Put2 commands with extensible options.\n`FileHeaderV2` and `FileTrailerV2` structures with extensible metadata.",
         CMSG_SMSG_2 => Compatibility::Level(3) => "Version 2 of `ClientMessage` and `ServerMessage` with extensible attributes.\n`CredentialsType` enum.",
         MKDIR_SETMETA_LS => Compatibility::Level(4) => "CreateDirectory, SetMetadata, ListFiles commands",
+        MKDIR_ALL => Compatibility::Level(5) => "CreateDirectory uses create_dir_all; client may submit all mkdir requests in parallel regardless of depth",
     }
     // Note: When adding a new compatibility level, don't forget to update OUR_COMPATIBILITY_LEVEL.
 );

--- a/qcp/src/protocol/compat.rs
+++ b/qcp/src/protocol/compat.rs
@@ -61,7 +61,8 @@ def_enum!(
         GET2_PUT2 => Compatibility::Level(2) => "Get2 and Put2 commands with extensible options.\n`FileHeaderV2` and `FileTrailerV2` structures with extensible metadata.",
         CMSG_SMSG_2 => Compatibility::Level(3) => "Version 2 of `ClientMessage` and `ServerMessage` with extensible attributes.\n`CredentialsType` enum.",
         MKDIR_SETMETA_LS => Compatibility::Level(4) => "CreateDirectory, SetMetadata, ListFiles commands",
-        MKDIR_ALL => Compatibility::Level(5) => "CreateDirectory uses create_dir_all; client may submit all mkdir requests in parallel regardless of depth",
+        PARALLEL_DEGREE => Compatibility::Level(5) => "Parallel Degree attribute",
+        SKIP_IF_SAME_SIZE => Compatibility::Level(5) => "SkipIfSameSize attribute",
     }
     // Note: When adding a new compatibility level, don't forget to update OUR_COMPATIBILITY_LEVEL.
 );
@@ -167,5 +168,17 @@ mod test {
 
         assert!(!Compatibility::Level(2).supports(Feature::CMSG_SMSG_2));
         assert!(Compatibility::Level(3).supports(Feature::CMSG_SMSG_2));
+
+        // PARALLEL is a Level(5) feature
+        assert!(!Compatibility::Level(4).supports(Feature::PARALLEL_DEGREE));
+        assert!(Compatibility::Level(5).supports(Feature::PARALLEL_DEGREE));
+        assert!(Compatibility::Newer.supports(Feature::PARALLEL_DEGREE));
+        assert!(!Compatibility::Unknown.supports(Feature::PARALLEL_DEGREE));
+
+        // SKIP_IF_SAME_SIZE is a Level(5) feature
+        assert!(!Compatibility::Level(4).supports(Feature::SKIP_IF_SAME_SIZE));
+        assert!(Compatibility::Level(5).supports(Feature::SKIP_IF_SAME_SIZE));
+        assert!(Compatibility::Newer.supports(Feature::SKIP_IF_SAME_SIZE));
+        assert!(!Compatibility::Unknown.supports(Feature::SKIP_IF_SAME_SIZE));
     }
 }

--- a/qcp/src/protocol/control.rs
+++ b/qcp/src/protocol/control.rs
@@ -58,7 +58,7 @@ pub const BANNER: &str = "qcp-server-2\n";
 pub const OLD_BANNER: &str = "qcp-server-1\n";
 
 /// The protocol compatibility version implemented by this crate
-pub(crate) const OUR_COMPATIBILITY_NUMERIC: u16 = 4;
+pub(crate) const OUR_COMPATIBILITY_NUMERIC: u16 = 5;
 /// The protocol compatibility version implemented by this crate
 pub const OUR_COMPATIBILITY_LEVEL: Compatibility = Compatibility::Level(OUR_COMPATIBILITY_NUMERIC);
 

--- a/qcp/src/protocol/control.rs
+++ b/qcp/src/protocol/control.rs
@@ -107,6 +107,9 @@ fn display_opt<T: std::fmt::Display>(label: &str, value: Option<&T>) -> String {
 /// The following compatibility levels are defined:
 /// * 1: Introduced in qcp 0.3.
 /// * 2: Introduced in qcp 0.5.
+/// * 3: Introduced in qcp 0.6.
+/// * 4: Introduced in qcp 0.8.
+/// * 5: Introduced in qcp 0.9.
 ///
 /// See [`crate::protocol::compat::Feature`] for a mapping from compatibility levels to specific features.
 ///

--- a/qcp/src/protocol/control/client_msg.rs
+++ b/qcp/src/protocol/control/client_msg.rs
@@ -207,6 +207,10 @@ impl ClientMessageV2 {
             self.attributes
                 .push(ClientMessage2Attributes::QuicTimeout.with_unsigned(t));
         }
+        if let Some(p) = our_config.parallel {
+            self.attributes
+                .push(ClientMessage2Attributes::ParallelDegree.with_unsigned(p));
+        }
         // DirectionOfTravel is set up by set_direction()
     }
 }
@@ -352,6 +356,9 @@ pub enum ClientMessage2Attributes {
     /// Connection timeout for the QUIC endpoints, in seconds.
     /// Data is [`crate::protocol::Variant::Unsigned`].
     QuicTimeout,
+    /// The number of files to transfer concurrently.
+    /// Data is [`crate::protocol::Variant::Unsigned`].
+    ParallelDegree,
 }
 impl DataTag for ClientMessage2Attributes {
     fn debug_data(&self, data: &Variant) -> String {
@@ -545,6 +552,7 @@ mod test {
             tls_auth_type: None,
             aes256: None,
             io_buffer_size: None,
+            parallel: None,
         };
 
         let cmsg = {

--- a/qcp/src/protocol/control/client_msg.rs
+++ b/qcp/src/protocol/control/client_msg.rs
@@ -2,6 +2,7 @@
 // (c) 2024-25 Ross Younger
 
 use super::{CongestionController, ConnectionType, display_opt, display_opt_uint};
+use crate::protocol::compat::Feature;
 use crate::protocol::prelude::*;
 use crate::{
     config::Configuration_Optional,
@@ -168,6 +169,7 @@ impl ClientMessageV2 {
         &mut self,
         remote_config: bool,
         our_config: &Configuration_Optional,
+        compat: Compatibility,
     ) {
         if remote_config {
             self.attributes
@@ -207,7 +209,9 @@ impl ClientMessageV2 {
             self.attributes
                 .push(ClientMessage2Attributes::QuicTimeout.with_unsigned(t));
         }
-        if let Some(p) = our_config.parallel {
+        if let Some(p) = our_config.parallel
+            && compat.supports(Feature::PARALLEL_DEGREE)
+        {
             self.attributes
                 .push(ClientMessage2Attributes::ParallelDegree.with_unsigned(p));
         }
@@ -442,7 +446,7 @@ impl ClientMessage {
         assert!(cert.data.is_bytes());
         if compat.supports(Feature::CMSG_SMSG_2) {
             let mut msg = ClientMessageV2::new(cert, connection_type);
-            msg.apply_config_attributes(remote_config, my_config);
+            msg.apply_config_attributes(remote_config, my_config, compat);
             msg.into()
         } else {
             let cert_bytes = cert.data.into_bytes().unwrap_or_default();

--- a/qcp/src/protocol/control/server_msg.rs
+++ b/qcp/src/protocol/control/server_msg.rs
@@ -279,6 +279,9 @@ pub enum ServerMessage2Attributes {
     /// Connection timeout for the QUIC endpoints, in seconds.
     /// Data is [`crate::protocol::Variant::Unsigned`].
     QuicTimeout,
+    /// The number of files to transfer concurrently.
+    /// Data is [`crate::protocol::Variant::Unsigned`].
+    ParallelDegree,
 }
 
 impl DataTag for ServerMessage2Attributes {}
@@ -299,6 +302,10 @@ impl ServerMessageV2 {
         if config.timeout != 0 {
             self.attributes
                 .push(ServerMessage2Attributes::QuicTimeout.with_unsigned(config.timeout));
+        }
+        if config.parallel > 1 {
+            self.attributes
+                .push(ServerMessage2Attributes::ParallelDegree.with_unsigned(config.parallel));
         }
         // WarningMessage is set up when the message is created.
     }
@@ -333,6 +340,9 @@ impl Provider for ServerMessageV2 {
                     }
                     ServerMessage2Attributes::QuicTimeout => {
                         insert("timeout", data.coerce_unsigned().into());
+                    }
+                    ServerMessage2Attributes::ParallelDegree => {
+                        insert("parallel", data.coerce_unsigned().into());
                     }
                     // attributes not forming part of the configuration:
                     ServerMessage2Attributes::WarningMessage

--- a/qcp/src/protocol/control/server_msg.rs
+++ b/qcp/src/protocol/control/server_msg.rs
@@ -2,7 +2,8 @@
 // (c) 2024-25 Ross Younger
 
 use crate::Configuration;
-use crate::protocol::control::{CongestionController, CredentialsType};
+use crate::protocol::compat::Feature;
+use crate::protocol::control::{Compatibility, CongestionController, CredentialsType};
 use crate::protocol::prelude::*;
 use engineering_repr::EngineeringRepr as _;
 use figment::{
@@ -63,7 +64,7 @@ impl ServerMessage {
                 rtt: config.rtt,
                 ..Default::default()
             };
-            msg.apply_config_attributes(config);
+            msg.apply_config_attributes(config, compat);
             msg.into()
         } else {
             let cert_bytes = credentials.data.into_bytes().unwrap_or_default();
@@ -287,7 +288,11 @@ pub enum ServerMessage2Attributes {
 impl DataTag for ServerMessage2Attributes {}
 
 impl ServerMessageV2 {
-    pub(crate) fn apply_config_attributes(&mut self, config: &Configuration) {
+    pub(crate) fn apply_config_attributes(
+        &mut self,
+        config: &Configuration,
+        compat: Compatibility,
+    ) {
         if config.congestion != CongestionController::default() {
             self.attributes.push(
                 ServerMessage2Attributes::CongestionController
@@ -303,7 +308,7 @@ impl ServerMessageV2 {
             self.attributes
                 .push(ServerMessage2Attributes::QuicTimeout.with_unsigned(config.timeout));
         }
-        if config.parallel > 1 {
+        if config.parallel > 1 && compat.supports(Feature::PARALLEL_DEGREE) {
             self.attributes
                 .push(ServerMessage2Attributes::ParallelDegree.with_unsigned(config.parallel));
         }
@@ -526,7 +531,7 @@ mod test {
         mgr.merge_provider(&cfg);
         let final_cfg = mgr.get::<Configuration>().unwrap();
         let mut msg = ServerMessageV2::default();
-        msg.apply_config_attributes(&final_cfg);
+        msg.apply_config_attributes(&final_cfg, Compatibility::Level(5));
 
         let attrs = &msg.attributes;
 

--- a/qcp/src/protocol/session/command.rs
+++ b/qcp/src/protocol/session/command.rs
@@ -141,7 +141,7 @@ pub enum CommandParam {
     /// after receiving it; if they match it responds with [`Status::Skipped`] instead of
     /// accepting the payload.
     ///
-    /// Introduced in qcp 0.10 with `VersionCompatibility=V2`.
+    /// Introduced in qcp 0.9 with compatibility level 5.
     SkipIfSameSize,
 }
 impl DataTag for CommandParam {}

--- a/qcp/src/protocol/session/command.rs
+++ b/qcp/src/protocol/session/command.rs
@@ -138,7 +138,7 @@ pub enum CommandParam {
     ///
     /// For [`Command::Put2`] commands: the associated [`Variant`] data is empty.
     /// The server compares the destination file size with the source size from the [`FileHeader`]
-    /// after receiving it; if they match it responds with [`Status::Skipped`] instead of
+    /// after receiving it; if they match it responds with [`Status::Skipped`](crate::protocol::session::Status::Skipped) instead of
     /// accepting the payload.
     ///
     /// Introduced in qcp 0.9 with compatibility level 5.

--- a/qcp/src/protocol/session/command.rs
+++ b/qcp/src/protocol/session/command.rs
@@ -128,6 +128,21 @@ pub enum CommandParam {
     ///
     /// Introduced in qcp 0.8 with compatibility level 4
     Recurse,
+
+    /// Skip the transfer if the destination file exists and has the same size as the source.
+    ///
+    /// For [`Command::Get2`] commands: the associated [`Variant`] data is the local destination
+    /// file size as [`Variant::Unsigned`]. The server compares this with the source file size
+    /// before streaming; if they match it responds with [`Status::Skipped`](crate::protocol::session::Status::Skipped)
+    /// instead of sending the file.
+    ///
+    /// For [`Command::Put2`] commands: the associated [`Variant`] data is empty.
+    /// The server compares the destination file size with the source size from the [`FileHeader`]
+    /// after receiving it; if they match it responds with [`Status::Skipped`] instead of
+    /// accepting the payload.
+    ///
+    /// Introduced in qcp 0.10 with `VersionCompatibility=V2`.
+    SkipIfSameSize,
 }
 impl DataTag for CommandParam {}
 

--- a/qcp/src/protocol/session/response.rs
+++ b/qcp/src/protocol/session/response.rs
@@ -231,7 +231,7 @@ pub enum Status {
     /// Destination file was skipped because it already exists with the same size as the source.
     ///
     /// This status is only sent in response to a command that included the
-    /// [`CommandParam::SkipIfSameSize`](crate::protocol::session::CommandParam::SkipIfSameSize) option.
+    /// [`CommandParam::SkipIfSameSize`] option.
     Skipped = 11,
 }
 

--- a/qcp/src/protocol/session/response.rs
+++ b/qcp/src/protocol/session/response.rs
@@ -228,6 +228,11 @@ pub enum Status {
     ItIsAFile = 8,
     UnknownError = 9,
     EncodingFailed = 10,
+    /// Destination file was skipped because it already exists with the same size as the source.
+    ///
+    /// This status is only sent in response to a command that included the
+    /// [`CommandParam::SkipIfSameSize`](crate::protocol::session::CommandParam::SkipIfSameSize) option.
+    Skipped = 11,
 }
 
 impl From<Status> for Uint {

--- a/qcp/src/server/connection.rs
+++ b/qcp/src/server/connection.rs
@@ -10,11 +10,9 @@ use crate::{
     },
 };
 
-use async_trait::async_trait;
 use quinn::ConnectionStats;
 use tracing::{debug, error, trace};
 
-#[async_trait]
 trait Connection<SS: QcpSS, RS: QcpRS> {
     async fn accept_bi(&self) -> Result<(SS, RS), quinn::ConnectionError>;
     fn stats(&self) -> ConnectionStats;
@@ -22,7 +20,6 @@ trait Connection<SS: QcpSS, RS: QcpRS> {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))] // This is a thin adaptor, not worth testing
-#[async_trait]
 impl Connection<quinn::SendStream, quinn::RecvStream> for quinn::Connection {
     async fn accept_bi(
         &self,
@@ -101,7 +98,6 @@ mod tests {
     use super::Connection;
 
     use assertables::assert_contains;
-    use async_trait::async_trait;
     use quinn::{ApplicationClose, ConnectionClose, ConnectionStats, TransportErrorCode};
     use tokio_test::io::{Builder, Mock};
 
@@ -120,7 +116,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl Connection<Mock, Mock> for MockConnection {
         async fn accept_bi(&self) -> Result<(Mock, Mock), quinn::ConnectionError> {
             if let Some(e) = &self.err {

--- a/qcp/src/server/stream.rs
+++ b/qcp/src/server/stream.rs
@@ -102,8 +102,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_put() {
+        // Trailing slash indicates an explicit directory, which must exist.
         let cmd = Command::Put(PutArgs {
-            filename: "/fjds/no-such-file.txt".to_string(),
+            filename: "/fjds/no-such-file.txt/".to_string(),
         });
         let resp = test_handler(cmd, 1).await;
         assert_eq!(resp.status, Status::DirectoryDoesNotExist);
@@ -120,8 +121,9 @@ mod tests {
     }
     #[tokio::test]
     async fn handle_put2() {
+        // Trailing slash indicates an explicit directory, which must exist.
         let cmd = Command::Put2(Put2Args {
-            filename: String::from("/blah/no-such-file"),
+            filename: String::from("/blah/no-such-file/"),
             ..Default::default()
         });
         let resp = test_handler(cmd, 3).await;

--- a/qcp/src/server/stream.rs
+++ b/qcp/src/server/stream.rs
@@ -53,8 +53,8 @@ mod tests {
             common::{ProtocolMessage, SendReceivePair},
             control::Compatibility,
             session::{
-                Command, CreateDirectoryArgs, Get2Args, GetArgs, Put2Args, PutArgs, Response,
-                ResponseV1, SetMetadataArgs, Status,
+                Command, CreateDirectoryArgs, Get2Args, GetArgs, Response, ResponseV1,
+                SetMetadataArgs, Status,
             },
         },
     };
@@ -101,16 +101,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_put() {
-        // Trailing slash indicates an explicit directory, which must exist.
-        let cmd = Command::Put(PutArgs {
-            filename: "/fjds/no-such-file.txt/".to_string(),
-        });
-        let resp = test_handler(cmd, 1).await;
-        assert_eq!(resp.status, Status::DirectoryDoesNotExist);
-    }
-
-    #[tokio::test]
     async fn handle_get2() {
         let cmd = Command::Get2(Get2Args {
             filename: String::from("/no-such-file"),
@@ -118,16 +108,6 @@ mod tests {
         });
         let resp = test_handler(cmd, 3).await;
         assert_eq!(resp.status, Status::FileNotFound);
-    }
-    #[tokio::test]
-    async fn handle_put2() {
-        // Trailing slash indicates an explicit directory, which must exist.
-        let cmd = Command::Put2(Put2Args {
-            filename: String::from("/blah/no-such-file/"),
-            ..Default::default()
-        });
-        let resp = test_handler(cmd, 3).await;
-        assert_eq!(resp.status, Status::DirectoryDoesNotExist);
     }
     #[tokio::test]
     async fn handle_mkdir() {

--- a/qcp/src/session/common.rs
+++ b/qcp/src/session/common.rs
@@ -33,6 +33,16 @@ where
         .await
 }
 
+/// Helper function for sending a Skipped response (destination exists with the same size)
+pub(super) async fn send_skipped<W>(send: &mut W) -> anyhow::Result<()>
+where
+    W: AsyncWriteExt + std::marker::Unpin + Send,
+{
+    Response::V1(ResponseV1::new(Status::Skipped.into(), None))
+        .to_writer_async_framed(send)
+        .await
+}
+
 pub(crate) fn io_error_to_status(io: &std::io::Error) -> (Status, Option<String>) {
     match io.kind() {
         ErrorKind::NotFound => (Status::FileNotFound, None),

--- a/qcp/src/session/get.rs
+++ b/qcp/src/session/get.rs
@@ -83,6 +83,14 @@ impl CommandHandler for GetHandler {
         let header = FileHeader::from_reader_async_framed(&mut inner.stream.recv).await?;
         trace!("{header:?}");
         let header = FileHeaderV2::from(header);
+
+        // Automatically create parent directories for the destination file if they don't exist.
+        if let Some(parent) = std::path::Path::new(dest).parent()
+            && !parent.as_os_str().is_empty()
+        {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
         let mut file = TokioFile::create_or_truncate(dest, &header).await?;
 
         // Now we know how much we're receiving, update the chrome.
@@ -312,6 +320,25 @@ mod test {
             assert_eq!(r1?.stats.payload_bytes, contents.len() as u64);
             assert!(r2.is_ok());
             let readback = std::fs::read_to_string("file2")?;
+            assert_eq!(readback, contents);
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn get_creates_missing_parent_directory() -> Result<()> {
+        let contents = "hello nested";
+        LitterTray::try_with_async(async |tray| {
+            let _ = tray.create_text("file1", contents)?;
+            let (r1, r2) = test_get_main("s:file1", "created_dir/nested_file").await?;
+            assert!(
+                r1.is_ok(),
+                "GET should succeed and automatically create the missing parent directory"
+            );
+            assert_eq!(r1?.stats.payload_bytes, contents.len() as u64);
+            assert!(r2.is_ok());
+            let readback = std::fs::read_to_string("created_dir/nested_file")?;
             assert_eq!(readback, contents);
             Ok(())
         })

--- a/qcp/src/session/get.rs
+++ b/qcp/src/session/get.rs
@@ -43,6 +43,16 @@ impl CommandHandler for GetHandler {
             if job.preserve {
                 options.push(CommandParam::PreserveMetadata.into());
             }
+            if job.skip_existing {
+                // If the local destination exists as a regular file, send its size so the server
+                // can decide to skip before streaming. We only do this for plain files; if dest
+                // is a directory we'd need to know the server-side filename first (not yet available).
+                if let Ok(dest_meta) = tokio::fs::metadata(dest).await
+                    && !dest_meta.is_dir()
+                {
+                    options.push(CommandParam::SkipIfSameSize.with_unsigned(dest_meta.len()));
+                }
+            }
             Command::Get2(Get2Args {
                 filename: filename.clone(),
                 options,
@@ -57,8 +67,18 @@ impl CommandHandler for GetHandler {
         inner.stream.send.flush().await?;
 
         trace!("await response");
-        let _ = Response::from_reader_async_framed(&mut inner.stream.recv)
-            .await?
+        let response = Response::from_reader_async_framed(&mut inner.stream.recv).await?;
+        if response.status() == Status::Skipped {
+            trace!("skipped (source and destination have same size)");
+            return Ok(RequestResult {
+                stats: CommandStats {
+                    skipped_files: 1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+        }
+        let _ = response
             .into_result()
             .with_context(|| format!("GET {filename} failed"))?;
 
@@ -112,6 +132,7 @@ impl CommandHandler for GetHandler {
             CommandStats {
                 payload_bytes: header.size.0,
                 peak_transfer_rate: meter.peak(),
+                skipped_files: 0,
             },
             None,
         ))
@@ -134,6 +155,20 @@ impl CommandHandler for GetHandler {
         };
         if file_original_meta.is_dir() {
             error_and_return!(stream, Status::ItIsADirectory);
+        }
+
+        // Check skip-existing: if client reported a destination size that matches our source, skip.
+        if let Some(Variant::Unsigned(Uint(dest_size))) =
+            args.options.find_option(CommandParam::SkipIfSameSize)
+            && *dest_size == file_original_meta.len()
+        {
+            trace!(
+                "skipping: source and destination have same size ({})",
+                dest_size
+            );
+            crate::session::common::send_skipped(&mut stream.send).await?;
+            stream.send.flush().await?;
+            return Ok(());
         }
 
         // We believe we can fulfil this request.

--- a/qcp/src/session/get.rs
+++ b/qcp/src/session/get.rs
@@ -2,7 +2,6 @@
 // (c) 2024-5 Ross Younger
 
 use anyhow::{Context as _, Result};
-use async_trait::async_trait;
 use std::path::PathBuf;
 use tokio::fs::File as TokioFile;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -24,13 +23,12 @@ use crate::util::FileExt as _;
 
 pub(crate) struct GetHandler;
 
-#[async_trait]
 impl CommandHandler for GetHandler {
     type Args = Get2Args;
 
-    async fn send_impl<'a, S: SendingStream, R: ReceivingStream>(
+    async fn send_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         job: &crate::client::CopyJobSpec,
         params: Parameters,
     ) -> Result<RequestResult> {
@@ -138,9 +136,9 @@ impl CommandHandler for GetHandler {
         ))
     }
 
-    async fn handle_impl<'a, S: SendingStream, R: ReceivingStream>(
+    async fn handle_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         args: &Get2Args,
     ) -> Result<()> {
         trace!("begin");

--- a/qcp/src/session/get.rs
+++ b/qcp/src/session/get.rs
@@ -41,7 +41,7 @@ impl CommandHandler for GetHandler {
             if job.preserve {
                 options.push(CommandParam::PreserveMetadata.into());
             }
-            if job.skip_existing {
+            if job.skip_existing && inner.compat.supports(Feature::SKIP_IF_SAME_SIZE) {
                 // If the local destination exists as a regular file, send its size so the server
                 // can decide to skip before streaming. We only do this for plain files; if dest
                 // is a directory we'd need to know the server-side filename first (not yet available).
@@ -166,6 +166,7 @@ impl CommandHandler for GetHandler {
         // Check skip-existing: if client reported a destination size that matches our source, skip.
         if let Some(Variant::Unsigned(Uint(dest_size))) =
             args.options.find_option(CommandParam::SkipIfSameSize)
+            && compat.supports(Feature::SKIP_IF_SAME_SIZE)
             && *dest_size == file_original_meta.len()
         {
             trace!(

--- a/qcp/src/session/handler.rs
+++ b/qcp/src/session/handler.rs
@@ -2,7 +2,6 @@
 // (c) 2025 Ross Younger
 
 use anyhow::Result;
-use async_trait::async_trait;
 use indicatif::{MultiProgress, ProgressBar};
 
 use crate::client::progress::style_for;
@@ -13,25 +12,24 @@ use crate::{Parameters, client::CopyJobSpec, config::Configuration};
 use super::{RequestResult, SessionCommandImpl};
 
 /// Trait for command-specific behavior - the extension point for new commands
-#[async_trait]
 pub(crate) trait CommandHandler: Send + Sized {
     /// Associated type for command arguments
     type Args: Send;
 
     /// Client-side implementation (has access to stream and compat)
-    async fn send_impl<'a, S: SendingStream, R: ReceivingStream>(
+    fn send_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         job: &CopyJobSpec,
         params: Parameters,
-    ) -> Result<RequestResult>;
+    ) -> impl std::future::Future<Output = Result<RequestResult>> + Send;
 
     /// Server-side implementation (has access to stream and compat)
-    async fn handle_impl<'a, S: SendingStream, R: ReceivingStream>(
+    fn handle_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         args: &Self::Args,
-    ) -> Result<()>;
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 }
 
 /// Client-side UI elements for commands that need them
@@ -160,20 +158,28 @@ impl<'a, S: SendingStream + 'static, R: ReceivingStream + 'static, H: CommandHan
     }
 }
 
-#[async_trait]
 impl<S: SendingStream + 'static, R: ReceivingStream + 'static, H: CommandHandler + 'static>
     SessionCommandImpl for SessionCommand<'_, S, R, H>
 {
-    async fn send(&mut self, job: &CopyJobSpec, params: Parameters) -> Result<RequestResult> {
-        self.handler.send_impl(&mut self.inner, job, params).await
+    fn send<'a>(
+        &'a mut self,
+        job: &'a CopyJobSpec,
+        params: Parameters,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<RequestResult>> + Send + 'a>>
+    {
+        Box::pin(async move { self.handler.send_impl(&mut self.inner, job, params).await })
     }
 
-    async fn handle(&mut self) -> Result<()> {
-        let args = self
-            .args
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("command handler missing args"))?;
-        self.handler.handle_impl(&mut self.inner, args).await
+    fn handle<'a>(
+        &'a mut self,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            let args = self
+                .args
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("command handler missing args"))?;
+            self.handler.handle_impl(&mut self.inner, args).await
+        })
     }
 }
 

--- a/qcp/src/session/ls.rs
+++ b/qcp/src/session/ls.rs
@@ -2,7 +2,6 @@
 // (c) 2025 Ross Younger
 
 use anyhow::Result;
-use async_trait::async_trait;
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, error, trace};
 use walkdir::WalkDir;
@@ -17,13 +16,12 @@ use crate::session::{CommandStats, RequestResult, error_and_return};
 
 pub(crate) struct ListingHandler;
 
-#[async_trait]
 impl CommandHandler for ListingHandler {
     type Args = ListArgs;
 
-    async fn send_impl<'a, S: SendingStream, R: ReceivingStream>(
+    async fn send_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         job: &crate::client::CopyJobSpec,
         params: Parameters,
     ) -> Result<RequestResult> {
@@ -68,9 +66,9 @@ impl CommandHandler for ListingHandler {
         Ok(RequestResult::new(CommandStats::default(), Some(data)))
     }
 
-    async fn handle_impl<'a, S: SendingStream, R: ReceivingStream>(
+    async fn handle_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         args: &ListArgs,
     ) -> Result<()> {
         let path = &args.path;

--- a/qcp/src/session/mkdir.rs
+++ b/qcp/src/session/mkdir.rs
@@ -71,7 +71,7 @@ impl CommandHandler for CreateDirectoryHandler {
                 anyhow::bail!("mkdir: existing entity {path:?} is neither file nor directory");
             }
         } else {
-            let result = tokio::fs::create_dir(path).await;
+            let result = tokio::fs::create_dir_all(path).await;
             if let Err(e) = result {
                 let str = e.to_string();
                 debug!("Could not mkdir: {str}");
@@ -156,11 +156,11 @@ mod test {
     #[tokio::test]
     async fn mkdir_missing_parent() -> Result<()> {
         LitterTray::try_with_async(async |_| {
+            // create_dir_all creates all missing parent components
             let (r1, r2) = test_mkdir_main("d/e").await?;
+            assert!(r1.is_ok());
             assert!(r2.is_ok());
-            let err = r1.expect_err("r1 should have errored");
-            let st = Status::from(err);
-            assert_eq!(st, Status::FileNotFound); // TODO: This should really be DirectoryDoesNotExist
+            assert!(is_dir("d/e").await.expect("is_dir failed"));
             Ok(())
         })
         .await

--- a/qcp/src/session/mkdir.rs
+++ b/qcp/src/session/mkdir.rs
@@ -90,7 +90,7 @@ mod test {
         client::CopyJobSpec,
         protocol::{
             control::Compatibility,
-            session::{Command, Status},
+            session::Command,
             test_helpers::{new_test_plumbing, read_from_stream},
         },
         session::RequestResult,

--- a/qcp/src/session/mkdir.rs
+++ b/qcp/src/session/mkdir.rs
@@ -2,7 +2,6 @@
 // (c) 2025 Ross Younger
 
 use anyhow::Result;
-use async_trait::async_trait;
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, trace};
 
@@ -15,13 +14,12 @@ use crate::session::{RequestResult, error_and_return, handler::CommandHandler};
 
 pub(crate) struct CreateDirectoryHandler;
 
-#[async_trait]
 impl CommandHandler for CreateDirectoryHandler {
     type Args = CreateDirectoryArgs;
 
-    async fn send_impl<'a, S: SendingStream, R: ReceivingStream>(
+    async fn send_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         job: &crate::client::CopyJobSpec,
         _params: Parameters,
     ) -> Result<RequestResult> {
@@ -52,9 +50,9 @@ impl CommandHandler for CreateDirectoryHandler {
         Ok(RequestResult::default())
     }
 
-    async fn handle_impl<'a, S: SendingStream, R: ReceivingStream>(
+    async fn handle_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         args: &CreateDirectoryArgs,
     ) -> Result<()> {
         let path = &args.dir_name;

--- a/qcp/src/session/mod.rs
+++ b/qcp/src/session/mod.rs
@@ -40,6 +40,8 @@ pub struct CommandStats {
     pub payload_bytes: u64,
     /// Peak transfer rate observed (in bytes per second); this is not terribly accurate at the moment, particularly on PUT commands
     pub peak_transfer_rate: u64,
+    /// Number of files skipped because the destination already had the same size as the source
+    pub skipped_files: u64,
 }
 
 /// Result of a successfully completed request

--- a/qcp/src/session/mod.rs
+++ b/qcp/src/session/mod.rs
@@ -16,7 +16,6 @@ mod set_meta;
 pub(crate) use get::test_shared;
 
 use anyhow::Result;
-use async_trait::async_trait;
 
 use crate::{Parameters, client::CopyJobSpec, protocol::session::ListData};
 
@@ -67,12 +66,15 @@ impl Default for RequestResult {
 }
 
 /// Common structure for session protocol commands
-#[async_trait]
 pub(crate) trait SessionCommandImpl: Send {
     /// Client side implementation, takes care of sending the command and all its
     /// traffic. Does not return until completion (or error).
     /// Returns the number of payload bytes received.
-    async fn send(&mut self, job: &CopyJobSpec, params: Parameters) -> Result<RequestResult>;
+    fn send<'a>(
+        &'a mut self,
+        job: &'a CopyJobSpec,
+        params: Parameters,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<RequestResult>> + Send + 'a>>;
 
     /// Server side implementation, takes care of handling the command and all its
     /// traffic. Does not return until completion (or error).
@@ -80,5 +82,7 @@ pub(crate) trait SessionCommandImpl: Send {
     /// If the command has arguments, the object constructor is expected to set them up.
     ///
     /// See also the [`crate::session::common::send_ok`] and [`crate::session::common::send_error`] helpers.
-    async fn handle(&mut self) -> Result<()>;
+    fn handle<'a>(
+        &'a mut self,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>>;
 }

--- a/qcp/src/session/put.rs
+++ b/qcp/src/session/put.rs
@@ -139,13 +139,8 @@ impl CommandHandler for PutHandler {
 
         // Initial checks. Is the destination valid, do we need to append the filename (from the `FileHeader`) to the destination path?
         // This is moderately tricky. It might validly be empty, a directory, a file, it might be a nonexistent file in an extant directory.
-        let mut path = PathBuf::from(destination.clone());
-        let append_filename = match check_dest_path(&path, destination) {
-            Ok(append) => append,
-            Err(status) => {
-                error_and_return!(stream, status);
-            }
-        };
+        let mut path = PathBuf::from(destination);
+        let append_filename = check_dest_path(&path, destination);
 
         let header = FileHeader::from_reader_async_framed(&mut stream.recv).await?;
         trace!("{header:?}");
@@ -289,25 +284,19 @@ async fn check_send_result(
 
 /// Determines whether to append the source filename to the destination path.
 ///
-/// Returns `Ok(true)` to append the source filename, `Ok(false)` if the full path is specified,
-/// or `Err(Status::DirectoryDoesNotExist)` if the destination is explicitly a directory but doesn't exist.
-fn check_dest_path(path: &Path, destination: &str) -> Result<bool, Status> {
+/// Returns `true` to append the source filename, or `false` if the full path is specified.
+fn check_dest_path(path: &Path, destination: &str) -> bool {
     if destination.is_empty() || destination == "." {
         // Easy case: copying to current working directory
-        Ok(true)
+        true
     } else if path.is_dir() || path.is_file() {
         // The destination exists; append filename only if it is a directory.
-        Ok(path.is_dir())
+        path.is_dir()
+    } else if destination.ends_with(std::path::MAIN_SEPARATOR) {
+        trace!("Nonexistent destination {destination} treated as directory");
+        true
     } else {
-        // The given destination does not exist.
-        // - If clearly intended as a directory (ends with / or \): error (use CreateDirectory instead).
-        // - Otherwise: we allow it, and the caller will create missing parent directories automatically.
-        if destination.ends_with(std::path::MAIN_SEPARATOR) {
-            debug!("Nonexistent destination directory {destination}");
-            return Err(Status::DirectoryDoesNotExist);
-        }
-        // Parent directory will be created automatically by the caller if needed.
-        Ok(false)
+        false
     }
 }
 
@@ -519,19 +508,18 @@ mod test {
     }
 
     #[tokio::test]
-    async fn write_fail_dest_dir_missing() -> Result<()> {
+    async fn write_creates_missing_destination_directory() -> Result<()> {
         let contents = "foo";
         LitterTray::try_with_async(async |tray| {
             let _ = tray.create_text("file1", contents)?;
             let (r1, r2) = test_put_main("file1", "server:destdir/", false).await?;
-            let r1 = r1.unwrap_err();
-            let status = Status::from(r1);
-            if cfg!(windows) {
-                assert_eq!(status, Status::IoError);
-            } else {
-                assert_eq!(status, Status::DirectoryDoesNotExist);
-            }
+            assert!(
+                r1.is_ok(),
+                "PUT should succeed and create the missing destination directory"
+            );
             assert!(r2.is_ok());
+            let readback = std::fs::read_to_string("destdir/file1")?;
+            assert_eq!(readback, contents);
             Ok(())
         })
         .await

--- a/qcp/src/session/put.rs
+++ b/qcp/src/session/put.rs
@@ -2,14 +2,16 @@
 // (c) 2024-5 Ross Younger
 
 use anyhow::{Context as _, Result, anyhow};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::fs::File as TokioFile;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, error, trace};
 
 use crate::Parameters;
+use crate::client::CopyJobSpec;
 use crate::protocol::common::{ProtocolMessage, ReceivingStream, SendingStream};
 use crate::protocol::compat::Feature;
+use crate::protocol::control::Compatibility;
 use crate::protocol::session::{
     Command, CommandParam, FileHeader, FileHeaderV2, FileTrailer, FileTrailerV2, Put2Args, PutArgs,
     Response, Status,
@@ -23,13 +25,12 @@ use crate::util::FileExt as _;
 
 pub(crate) struct PutHandler;
 
-#[async_trait::async_trait]
 impl CommandHandler for PutHandler {
     type Args = Put2Args;
 
-    async fn send_impl<'a, S: SendingStream, R: ReceivingStream>(
+    async fn send_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         job: &crate::client::CopyJobSpec,
         params: Parameters,
     ) -> Result<RequestResult> {
@@ -59,23 +60,7 @@ impl CommandHandler for PutHandler {
 
         trace!("sending command");
 
-        let cmd = if inner.compat.supports(Feature::GET2_PUT2) {
-            let mut options = vec![];
-            if job.preserve {
-                options.push(CommandParam::PreserveMetadata.into());
-            }
-            if job.skip_existing {
-                options.push(CommandParam::SkipIfSameSize.into());
-            }
-            Command::Put2(Put2Args {
-                filename: dest_filename.clone(),
-                options,
-            })
-        } else {
-            Command::Put(PutArgs {
-                filename: dest_filename.clone(),
-            })
-        };
+        let cmd = build_put_command(inner.compat, job, dest_filename);
         cmd.to_writer_async_framed(&mut outbound).await?;
         outbound.flush().await?;
 
@@ -110,32 +95,7 @@ impl CommandHandler for PutHandler {
             crate::util::io::copy_large(&mut file, &mut outbound, inner.config.io_buffer_size)
                 .await;
 
-        match result {
-            Ok(sent) if sent == src_meta.len() => (),
-            Ok(sent) => {
-                anyhow::bail!(
-                    "File sent size {sent} doesn't match its metadata {}",
-                    src_meta.len()
-                );
-            }
-            Err(e) => {
-                if e.kind() == tokio::io::ErrorKind::ConnectionReset {
-                    // Maybe the connection was cut, maybe the server sent something to help us inform the user.
-                    let Ok(response) =
-                        Response::from_reader_async_framed(&mut inner.stream.recv).await
-                    else {
-                        anyhow::bail!("connection closed unexpectedly");
-                    };
-                    let Response::V1(response) = response;
-                    anyhow::bail!(
-                        "remote closed connection: {:?}: {}",
-                        response.status,
-                        response.message.unwrap_or("(no message)".into())
-                    );
-                }
-                return Err(anyhow!(e).context("I/O error during PUT"));
-            }
-        }
+        check_send_result(result, src_meta.len(), &mut inner.stream.recv).await?;
 
         let trl = FileTrailer::for_file(inner.compat, &src_meta, job.preserve);
         trace!("send trailer {trl:?}");
@@ -167,9 +127,9 @@ impl CommandHandler for PutHandler {
         })
     }
 
-    async fn handle_impl<'a, S: SendingStream, R: ReceivingStream>(
+    async fn handle_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         args: &Put2Args,
     ) -> Result<()> {
         let destination = &args.filename;
@@ -180,39 +140,10 @@ impl CommandHandler for PutHandler {
         // Initial checks. Is the destination valid, do we need to append the filename (from the `FileHeader`) to the destination path?
         // This is moderately tricky. It might validly be empty, a directory, a file, it might be a nonexistent file in an extant directory.
         let mut path = PathBuf::from(destination.clone());
-        let append_filename = if destination.is_empty() || destination == "." {
-            // Easy case: copying to current working directory
-            true
-        } else if path.is_dir() || path.is_file() {
-            // The destination exists. This is another easy case; append filename only if it is a directory.
-            path.is_dir()
-        } else {
-            // The given destination does not exist. The possible cases here are:
-            // - The destination is clearly intended as a directory (ends with / or \).
-            //   This is an error (there's a separate CreateDirectory command for that).
-            if destination.ends_with(std::path::MAIN_SEPARATOR) {
-                // N.B. Path.has_trailing_sep() is currently only available in nightly
-                debug!("Nonexistent destination directory {destination}");
-                error_and_return!(stream, Status::DirectoryDoesNotExist);
-            }
-
-            // - The destination's parent directory exists => do not append the path
-            // - The destination's parent directory does not exist => error
-
-            let mut parent_dir = {
-                let mut tmp = path.clone();
-                let _ = tmp.pop();
-                tmp
-            };
-
-            if parent_dir.as_os_str().is_empty() {
-                // We're writing a file to the current working directory, so apply the is_dir check
-                parent_dir.push(".");
-            }
-            if parent_dir.is_dir() {
-                false // destination path is fully specified, do not append filename
-            } else {
-                error_and_return!(stream, Status::DirectoryDoesNotExist);
+        let append_filename = match check_dest_path(&path, destination) {
+            Ok(append) => append,
+            Err(status) => {
+                error_and_return!(stream, status);
             }
         };
 
@@ -295,6 +226,96 @@ async fn limited_copy(
 ) -> Result<u64, std::io::Error> {
     let mut limited = recv.take(n);
     crate::util::io::copy_large(&mut limited, f, buffer_size).await
+}
+
+/// Builds the PUT command based on negotiated compatibility and job options.
+fn build_put_command(compat: Compatibility, job: &CopyJobSpec, dest: &str) -> Command {
+    if compat.supports(Feature::GET2_PUT2) {
+        let mut options = vec![];
+        if job.preserve {
+            options.push(CommandParam::PreserveMetadata.into());
+        }
+        if job.skip_existing {
+            options.push(CommandParam::SkipIfSameSize.into());
+        }
+        Command::Put2(Put2Args {
+            filename: dest.to_string(),
+            options,
+        })
+    } else {
+        Command::Put(PutArgs {
+            filename: dest.to_string(),
+        })
+    }
+}
+
+/// Verifies the result of a payload send.
+/// On connection reset, attempts to read an error response from the stream for a better error message.
+async fn check_send_result(
+    result: Result<u64, std::io::Error>,
+    expected_len: u64,
+    recv: &mut impl ReceivingStream,
+) -> Result<()> {
+    match result {
+        Ok(sent) if sent == expected_len => Ok(()),
+        Ok(sent) => {
+            anyhow::bail!("File sent size {sent} doesn't match its metadata {expected_len}")
+        }
+        Err(e) => {
+            if e.kind() == tokio::io::ErrorKind::ConnectionReset {
+                // Maybe the connection was cut, maybe the server sent something to help us inform the user.
+                let Ok(response) = Response::from_reader_async_framed(recv).await else {
+                    anyhow::bail!("connection closed unexpectedly");
+                };
+                let Response::V1(response) = response;
+                anyhow::bail!(
+                    "remote closed connection: {:?}: {}",
+                    response.status,
+                    response.message.unwrap_or("(no message)".into())
+                );
+            }
+            Err(anyhow!(e).context("I/O error during PUT"))
+        }
+    }
+}
+
+/// Determines whether to append the source filename to the destination path.
+///
+/// Returns `Ok(true)` to append the source filename, `Ok(false)` if the full path is specified,
+/// or `Err(Status::DirectoryDoesNotExist)` if the destination directory doesn't exist.
+fn check_dest_path(path: &Path, destination: &str) -> Result<bool, Status> {
+    if destination.is_empty() || destination == "." {
+        // Easy case: copying to current working directory
+        Ok(true)
+    } else if path.is_dir() || path.is_file() {
+        // The destination exists; append filename only if it is a directory.
+        Ok(path.is_dir())
+    } else {
+        // The given destination does not exist.
+        // - If clearly intended as a directory (ends with / or \): error (use CreateDirectory instead).
+        // - If parent directory exists: the full path is specified, do not append.
+        // - Otherwise: error.
+        if destination.ends_with(std::path::MAIN_SEPARATOR) {
+            // N.B. Path.has_trailing_sep() is currently only available in nightly
+            debug!("Nonexistent destination directory {destination}");
+            return Err(Status::DirectoryDoesNotExist);
+        }
+        let mut parent_dir = {
+            let mut tmp = path.to_path_buf();
+            let _ = tmp.pop();
+            tmp
+        };
+        if parent_dir.as_os_str().is_empty() {
+            // We're writing a file to the current working directory
+            parent_dir.push(".");
+        }
+        if parent_dir.is_dir() {
+            Ok(false)
+        } else {
+            debug!("Nonexistent destination directory {destination}");
+            Err(Status::DirectoryDoesNotExist)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/qcp/src/session/put.rs
+++ b/qcp/src/session/put.rs
@@ -509,13 +509,15 @@ mod test {
 
     #[tokio::test]
     async fn write_creates_missing_destination_directory() -> Result<()> {
+        use std::path::MAIN_SEPARATOR;
         let contents = "foo";
         LitterTray::try_with_async(async |tray| {
             let _ = tray.create_text("file1", contents)?;
-            let (r1, r2) = test_put_main("file1", "server:destdir/", false).await?;
+            let destfile = format!("server:destdir{MAIN_SEPARATOR}");
+            let (r1, r2) = test_put_main("file1", &destfile, false).await?;
             assert!(
                 r1.is_ok(),
-                "PUT should succeed and create the missing destination directory"
+                "PUT should succeed and create the missing destination directory: {r1:?}"
             );
             assert!(r2.is_ok());
             let readback = std::fs::read_to_string("destdir/file1")?;

--- a/qcp/src/session/put.rs
+++ b/qcp/src/session/put.rs
@@ -161,6 +161,7 @@ impl CommandHandler for PutHandler {
             .options
             .find_option(CommandParam::SkipIfSameSize)
             .is_some()
+            && inner.compat.supports(Feature::SKIP_IF_SAME_SIZE)
             && let Ok(dest_meta) = tokio::fs::metadata(&path).await
             && dest_meta.len() == header.size.0
         {
@@ -242,7 +243,7 @@ fn build_put_command(compat: Compatibility, job: &CopyJobSpec, dest: &str) -> Co
         if job.preserve {
             options.push(CommandParam::PreserveMetadata.into());
         }
-        if job.skip_existing {
+        if job.skip_existing && compat.supports(Feature::SKIP_IF_SAME_SIZE) {
             options.push(CommandParam::SkipIfSameSize.into());
         }
         Command::Put2(Put2Args {

--- a/qcp/src/session/put.rs
+++ b/qcp/src/session/put.rs
@@ -170,6 +170,13 @@ impl CommandHandler for PutHandler {
             return Ok(());
         }
 
+        // Automatically create parent directories for the destination file if they don't exist.
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
         let mut file = match TokioFile::create_or_truncate(path, &header).await {
             Ok(f) => f,
             Err(e) => {
@@ -282,7 +289,7 @@ async fn check_send_result(
 /// Determines whether to append the source filename to the destination path.
 ///
 /// Returns `Ok(true)` to append the source filename, `Ok(false)` if the full path is specified,
-/// or `Err(Status::DirectoryDoesNotExist)` if the destination directory doesn't exist.
+/// or `Err(Status::DirectoryDoesNotExist)` if the destination is explicitly a directory but doesn't exist.
 fn check_dest_path(path: &Path, destination: &str) -> Result<bool, Status> {
     if destination.is_empty() || destination == "." {
         // Easy case: copying to current working directory
@@ -293,28 +300,13 @@ fn check_dest_path(path: &Path, destination: &str) -> Result<bool, Status> {
     } else {
         // The given destination does not exist.
         // - If clearly intended as a directory (ends with / or \): error (use CreateDirectory instead).
-        // - If parent directory exists: the full path is specified, do not append.
-        // - Otherwise: error.
+        // - Otherwise: we allow it, and the caller will create missing parent directories automatically.
         if destination.ends_with(std::path::MAIN_SEPARATOR) {
-            // N.B. Path.has_trailing_sep() is currently only available in nightly
             debug!("Nonexistent destination directory {destination}");
             return Err(Status::DirectoryDoesNotExist);
         }
-        let mut parent_dir = {
-            let mut tmp = path.to_path_buf();
-            let _ = tmp.pop();
-            tmp
-        };
-        if parent_dir.as_os_str().is_empty() {
-            // We're writing a file to the current working directory
-            parent_dir.push(".");
-        }
-        if parent_dir.is_dir() {
-            Ok(false)
-        } else {
-            debug!("Nonexistent destination directory {destination}");
-            Err(Status::DirectoryDoesNotExist)
-        }
+        // Parent directory will be created automatically by the caller if needed.
+        Ok(false)
     }
 }
 
@@ -508,14 +500,18 @@ mod test {
     }
 
     #[tokio::test]
-    async fn write_fail_parent_directory_missing() -> Result<()> {
+    async fn put_creates_missing_parent_directory() -> Result<()> {
         let contents = "xyzy";
         LitterTray::try_with_async(async |tray| {
             let _ = tray.create_text("file1", contents)?;
             let (r1, r2) = test_put_main("file1", "server:destdir/foo", false).await?;
-            let r1 = r1.unwrap_err();
-            assert_eq!(Status::from(r1), Status::DirectoryDoesNotExist);
+            assert!(
+                r1.is_ok(),
+                "PUT should succeed and automatically create the missing parent directory"
+            );
             assert!(r2.is_ok());
+            let readback = std::fs::read_to_string("destdir/foo")?;
+            assert_eq!(readback, contents);
             Ok(())
         })
         .await

--- a/qcp/src/session/put.rs
+++ b/qcp/src/session/put.rs
@@ -14,6 +14,7 @@ use crate::protocol::session::{
     Command, CommandParam, FileHeader, FileHeaderV2, FileTrailer, FileTrailerV2, Put2Args, PutArgs,
     Response, Status,
 };
+use crate::session::common::FindOption as _;
 use crate::session::handler::SessionCommandInner;
 use crate::session::{RequestResult, error_and_return, handler::CommandHandler};
 
@@ -63,6 +64,9 @@ impl CommandHandler for PutHandler {
             if job.preserve {
                 options.push(CommandParam::PreserveMetadata.into());
             }
+            if job.skip_existing {
+                options.push(CommandParam::SkipIfSameSize.into());
+            }
             Command::Put2(Put2Args {
                 filename: dest_filename.clone(),
                 options,
@@ -83,8 +87,20 @@ impl CommandHandler for PutHandler {
         hdr.to_writer_async_framed(&mut outbound).await?;
 
         trace!("await response");
-        let _ = Response::from_reader_async_framed(&mut inner.stream.recv)
-            .await?
+        let response = Response::from_reader_async_framed(&mut inner.stream.recv).await?;
+        if response.status() == Status::Skipped {
+            trace!("skipped (destination has same size)");
+            meter.stop().await;
+            progress_bar.finish_and_clear();
+            return Ok(RequestResult {
+                stats: crate::session::CommandStats {
+                    skipped_files: 1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+        }
+        let _ = response
             .into_result()
             .with_context(|| format!("PUTx {src_filename} failed"))?;
 
@@ -145,6 +161,7 @@ impl CommandHandler for PutHandler {
             stats: crate::session::CommandStats {
                 payload_bytes: payload_len,
                 peak_transfer_rate: meter.peak(),
+                skipped_files: 0,
             },
             ..Default::default()
         })
@@ -207,6 +224,21 @@ impl CommandHandler for PutHandler {
         if append_filename {
             path.push(&header.filename);
         }
+
+        // Check skip-existing: if destination has same size as source, skip the transfer.
+        if args
+            .options
+            .find_option(CommandParam::SkipIfSameSize)
+            .is_some()
+            && let Ok(dest_meta) = tokio::fs::metadata(&path).await
+            && dest_meta.len() == header.size.0
+        {
+            trace!("skipping: destination has same size ({})", header.size.0);
+            crate::session::common::send_skipped(&mut stream.send).await?;
+            stream.send.flush().await?;
+            return Ok(());
+        }
+
         let mut file = match TokioFile::create_or_truncate(path, &header).await {
             Ok(f) => f,
             Err(e) => {

--- a/qcp/src/session/set_meta.rs
+++ b/qcp/src/session/set_meta.rs
@@ -2,7 +2,6 @@
 // (c) 2025 Ross Younger
 
 use anyhow::Result;
-use async_trait::async_trait;
 use cfg_if::cfg_if;
 use tokio::io::AsyncWriteExt;
 use tracing::trace;
@@ -21,13 +20,12 @@ use std::os::unix::fs::PermissionsExt as _;
 
 pub(crate) struct SetMetadataHandler;
 
-#[async_trait]
 impl CommandHandler for SetMetadataHandler {
     type Args = SetMetadataArgs;
 
-    async fn send_impl<'a, S: SendingStream, R: ReceivingStream>(
+    async fn send_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         job: &crate::CopyJobSpec,
         _params: Parameters,
     ) -> Result<RequestResult> {
@@ -61,9 +59,9 @@ impl CommandHandler for SetMetadataHandler {
         Ok(RequestResult::default())
     }
 
-    async fn handle_impl<'a, S: SendingStream, R: ReceivingStream>(
+    async fn handle_impl<S: SendingStream, R: ReceivingStream>(
         &mut self,
-        inner: &mut SessionCommandInner<'a, S, R>,
+        inner: &mut SessionCommandInner<'_, S, R>,
         args: &SetMetadataArgs,
     ) -> Result<()> {
         let path = &args.path;

--- a/qcp/src/transport.rs
+++ b/qcp/src/transport.rs
@@ -60,8 +60,11 @@ pub fn create_config(
     let _ = mtu_cfg.upper_bound(params.max_mtu);
 
     let mut config = TransportConfig::default();
+    // Allow a few more concurrent streams than the requested parallel degree so quinn's flow
+    // control never becomes the bottleneck.
+    let max_streams = VarInt::from(u32::from(params.parallel.max(1)) + 2);
     let _ = config
-        .max_concurrent_bidi_streams(1u8.into())
+        .max_concurrent_bidi_streams(max_streams)
         .max_concurrent_uni_streams(0u8.into())
         .keep_alive_interval(Some(PROTOCOL_KEEPALIVE))
         .allow_spin(true)
@@ -87,12 +90,14 @@ pub fn create_config(
     }
 
     match mode {
-        // TODO: If we later support multiple streams at once, will need to consider receive_window and stream_receive_window.
+        // When parallel > 1 the connection-level receive window must accommodate all concurrent streams.
         ThroughputMode::Rx | ThroughputMode::Both => {
-            let rwnd: VarInt = params.recv_window().try_into()?;
+            let srwnd: VarInt = params.recv_window().try_into()?;
+            let n_streams = u64::from(params.parallel.max(1));
+            let crwnd: VarInt = params.recv_window().saturating_mul(n_streams).try_into()?;
             let _ = config
-                .receive_window(rwnd) // Not strictly essential as quinn defaults to unlimited
-                .stream_receive_window(rwnd) // essential; quinn defaults to 100Mbits x 100ms
+                .receive_window(crwnd) // connection-level: scale with parallelism
+                .stream_receive_window(srwnd) // per-stream: one BDP
                 .datagram_receive_buffer_size(Some(udp_buf));
         }
         ThroughputMode::Tx => (),
@@ -356,6 +361,13 @@ pub fn combine_bandwidth_configurations(
         server.timeout,
         |_: u16, _| CombinationResponse::Client,
         "timeout"
+    )?;
+    negotiate!(
+        ca.find_tag(ClientMessage2Attributes::ParallelDegree)
+            .map(|v| (v.coerce_unsigned() & 0xffff) as u16),
+        server.parallel,
+        |a: u16, b: u16| CombinationResponse::Combined(a.min(b).max(1)),
+        "parallel"
     )?;
 
     // Convert selected fields to human-friendly representations
@@ -705,5 +717,42 @@ mod tests {
         // this is a server-oriented configuration
         assert_eq!(c.tx, 333_444);
         assert_eq!(c.rx, 123_456);
+    }
+
+    #[test]
+    fn parallel_sets_max_concurrent_streams() {
+        // parallel=1 (default): max_concurrent_bidi_streams should be at least 1
+        let cfg = Configuration::system_default().clone();
+        assert_eq!(cfg.parallel, 1);
+        let (tc, _) = process_config(&cfg, ThroughputMode::Both);
+        // parallel=1 -> max_streams = 1+2 = 3
+        assert_contains!(tc, "max_concurrent_bidi_streams: 3");
+
+        // parallel=4: max_concurrent_bidi_streams should be at least 4
+        let mut cfg4 = Configuration::system_default().clone();
+        cfg4.parallel = 4;
+        let (tc4, _) = process_config(&cfg4, ThroughputMode::Both);
+        // parallel=4 -> max_streams = 4+2 = 6
+        assert_contains!(tc4, "max_concurrent_bidi_streams: 6");
+    }
+
+    #[test]
+    fn parallel_scales_receive_window() {
+        let mut cfg = Configuration::system_default().clone();
+        cfg.rx = 1_000_000;
+        cfg.rtt = 1000;
+        cfg.parallel = 1;
+        let (tc1, _) = process_config(&cfg, ThroughputMode::Rx);
+
+        cfg.parallel = 4;
+        let (tc4, _) = process_config(&cfg, ThroughputMode::Rx);
+
+        // Connection-level receive window should be 4x larger with parallel=4.
+        // With rx=1M, rtt=1s: bdp=1_000_000. parallel=1 => crwnd=1_000_000; parallel=4 => crwnd=4_000_000
+        assert_contains!(tc1, "receive_window: 1000000");
+        assert_contains!(tc4, "receive_window: 4000000");
+        // Per-stream window is unchanged (still one BDP)
+        assert_contains!(tc1, "stream_receive_window: 1000000");
+        assert_contains!(tc4, "stream_receive_window: 1000000");
     }
 }

--- a/qcp/src/transport.rs
+++ b/qcp/src/transport.rs
@@ -272,6 +272,7 @@ use crate::protocol::control::ClientMessageV1;
 pub fn combine_bandwidth_configurations(
     manager: &mut Manager,
     client: &ClientMessageV2,
+    compat: Compatibility,
 ) -> Result<Configuration> {
     use num_traits::AsPrimitive as _;
 
@@ -364,6 +365,7 @@ pub fn combine_bandwidth_configurations(
     )?;
     negotiate!(
         ca.find_tag(ClientMessage2Attributes::ParallelDegree)
+            .filter(|_| compat.supports(Feature::PARALLEL_DEGREE))
             .map(|v| (v.coerce_unsigned() & 0xffff) as u16),
         server.parallel,
         |a: u16, b: u16| CombinationResponse::Combined(a.min(b).max(1)),
@@ -497,7 +499,7 @@ mod tests {
             ..Default::default()
         };
 
-        let e = combine_bandwidth_configurations(&mut mgr, &mp).unwrap_err();
+        let e = combine_bandwidth_configurations(&mut mgr, &mp, Compatibility::Level(5)).unwrap_err();
         assert_contains!(
             e.to_string(),
             "server and client have incompatible congestion algorithm requirements"
@@ -531,7 +533,7 @@ mod tests {
             ..Default::default()
         };
 
-        let c = combine_bandwidth_configurations(&mut mgr, &mp).unwrap();
+        let c = combine_bandwidth_configurations(&mut mgr, &mp, Compatibility::Level(5)).unwrap();
         assert_matches!(
             c,
             Configuration {
@@ -713,7 +715,7 @@ mod tests {
             ..Default::default()
         };
 
-        let c = combine_bandwidth_configurations(&mut mgr, &cmsg).unwrap();
+        let c = combine_bandwidth_configurations(&mut mgr, &cmsg, Compatibility::Level(5)).unwrap();
         // this is a server-oriented configuration
         assert_eq!(c.tx, 333_444);
         assert_eq!(c.rx, 123_456);

--- a/qcp/src/transport.rs
+++ b/qcp/src/transport.rs
@@ -499,7 +499,8 @@ mod tests {
             ..Default::default()
         };
 
-        let e = combine_bandwidth_configurations(&mut mgr, &mp, Compatibility::Level(5)).unwrap_err();
+        let e =
+            combine_bandwidth_configurations(&mut mgr, &mp, Compatibility::Level(5)).unwrap_err();
         assert_contains!(
             e.to_string(),
             "server and client have incompatible congestion algorithm requirements"

--- a/qcp/src/util/dns.rs
+++ b/qcp/src/util/dns.rs
@@ -44,7 +44,10 @@ mod tests {
         let result = lookup_host_by_family("ipv4.google.com", AddressFamily::Inet).unwrap();
         assert!(result.is_ipv4());
     }
-    #[cfg_attr(target_os = "macos", ignore)] // GitHub OSX runners seem unable to look up ipv6.google.com?!
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "GitHub OSX runners seem unable to look up ipv6.google.com?!"
+    )]
     #[cfg_attr(msvc, ignore)] // GitHub Windows runners seem unable to look up ipv6.google.com?!
     #[tokio::test]
     async fn ipv6() {

--- a/qcp/src/util/file_ext.rs
+++ b/qcp/src/util/file_ext.rs
@@ -11,7 +11,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use async_trait::async_trait;
 use cfg_if::cfg_if;
 use tokio::fs::File as TokioFile;
 
@@ -59,7 +58,6 @@ impl OpenOptionsExt for tokio::fs::OpenOptions {
     }
 }
 
-#[async_trait]
 /// Extension trait for `tokio::fs::File`
 pub(crate) trait FileExt {
     /// Opens a local file for reading, returning a filehandle and metadata.
@@ -83,7 +81,6 @@ pub(crate) trait FileExt {
     ) -> anyhow::Result<TokioFile>;
 }
 
-#[async_trait]
 impl FileExt for TokioFile {
     #[allow(
         renamed_and_removed_lints, // for elided_named_lifetimes

--- a/qcp/src/util/socket.rs
+++ b/qcp/src/util/socket.rs
@@ -160,8 +160,14 @@ mod test {
         let _s = bind_range_for_address(UNSPECIFIED, range).unwrap();
     }
 
-    #[cfg_attr(target_os = "macos", ignore)] // GitHub OSX runners allow binding to ports <1024...
-    #[cfg_attr(msvc, ignore)] // MSVC doesn't implement the unix privilege check, obviously
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "GitHub OSX runners allow binding to ports <1024..."
+    )]
+    #[cfg_attr(
+        msvc,
+        ignore = "MSVC doesn't implement the unix privilege check, obviously"
+    )]
     #[test]
     fn bind_range_fails_non_root() {
         let range = PortRange { begin: 1, end: 2 };


### PR DESCRIPTION
Closes #184, #195

* Now we can use `-j` option to specify number of parallel streams.
* Directory structure is now created upfront of starting file transfer
* `--skip-existing` option skip transfers of files already existing with exactly same size on target side