### PR TITLE
chore: bump nix version to v0.9.0 & update to nixpkgs to 26.05

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,7 +10,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qcp";
-  version = "0.8.3";
+  version = "0.9.0";
 
   # Tags required to fix the binary version
   GITHUB_REF_TYPE = "tag";
@@ -20,10 +20,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "crazyscot";
     repo = "qcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-sPvJHE2Xa29rz5zZeW0JGi0LWgJt50wLY+oUCDREjrI=";
+    hash = "sha256-mPpYLYflCt2izNelD2R9FF66dNCiFmOVsTPgpgI7LzQ=";
   };
 
-  cargoHash = "sha256-HTXVmRhs/KQmXv66YfqYrH/43EdN0NTDlaymJ7GdAjQ=";
+  cargoHash = "sha256-iP0A3ycaCwhhxOsz1Ze/z0voZ2m/Py/zHBgaLAcrdaw=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764406085,
-        "narHash": "sha256-CYbMp8hwuOf4umokSNp+t1s4Hjd4vxXq4S5CD+xvgNs=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9561691c9f450fad7c3526916e1c4f44be0d1192",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -2,7 +2,7 @@
   description = "The QUIC Copier (qcp) is an experimental high-performance remote file copy utility for long-distance internet connections.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-26.05";
   };
 
   outputs =


### PR DESCRIPTION
Simple version bump and a nixpkgs bump in order to fix cargo and to match current release.